### PR TITLE
Update ESLint 0.6.2 -> 0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "~0.6.2"
+    "eslint": "~0.7.4"
   }
 }


### PR DESCRIPTION
Update to the most recent version of ESLint. The current linter-eslint would break if you e.g. tried to use a rule "no-trailing-spaces" that was introduced after 0.6.2 (Also, would be cool to get better error messages!)
