### PR TITLE
Make eslintRulesDir relative to working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You can configure linter-eslint by editing ~/.atom/config.cson (choose Open Your
 
 **Note**: This plugin finds the nearest .eslintrc file and uses the `--config` command line argument to use that file. If no config file is found, it uses the `defaultEslintConfig` setting instead.
 
+The `eslintRulesDir` is relative to the working directory (project root).
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -15,11 +15,14 @@ class LinterESLint extends Linter
 
       config = findFile(@cwd, ['.eslintrc']) or @defaultEslintConfig
 
+      # Relative to project root
+      rulesDir = findFile(@cwd, [@rulesDir], false, 0) if @rulesDir
+
       if config
         cmd += " --config #{config}"
 
-      if @rulesDir
-        cmd += " --rulesdir #{@rulesDir}"
+      if rulesDir
+        cmd += " --rulesdir #{rulesDir}"
 
       cmd
   })


### PR DESCRIPTION
If 'eslintRulesDir' is set, attempt to find it relative to the project root.

This little change makes it possible to have project-specific rulesets, as the rule directory doesn't need to be absolute (although that's perfectly fine too).

Without this, setting the value to e.g. "eslint-rules" would typically search in directory of the currently edited file, and result in an error such as "Error: ENOENT, no such file or directory '...myProject/app/views/MyView/eslint-rules'".
