### PR TITLE
Update ESLint to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.9.2"
+    "eslint": "^0.10.1"
   }
 }


### PR DESCRIPTION
This could possibly throw some errors when the local `.eslintrc` contains rules that are no longer valid in 0.10.

Fixes #19.
