### PR TITLE
Add Extensions Option (WIP)

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -5,6 +5,11 @@ module.exports =
     eslintRulesDir:
       type: 'string'
       default: ''
+    eslintExtensions:
+      type: 'array'
+      default: ['js']
+      items:
+        type: 'string'
 
   activate: ->
     console.log 'activate linter-eslint'

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -33,6 +33,11 @@ class LinterESLint extends Linter
     if rulesDir && fs.existsSync(rulesDir)
       options.rulePaths = [rulesDir]
 
+    # set file extensions to be linted
+    options.extensions = @extensions
+
+    console.log 'eslint opts', options
+
     # init eslint CLIEngine (cli engine is used for getting linter config and test ignored files)
     engine = new CLIEngine(options)
 
@@ -41,7 +46,7 @@ class LinterESLint extends Linter
       return callback([])
 
     config = engine.getConfigForFile(origPath)
-    
+
     # Currently, linter-eslinter does not support eslint plugins. To not cause
     # any "Definition for rule ... was not found." errors, we remove any plugin
     # based rules from the config.
@@ -71,7 +76,11 @@ class LinterESLint extends Linter
     atom.config.observe 'linter-eslint.eslintRulesDir', (newDir) =>
       @rulesDir = newDir
 
+    atom.config.observe 'linter-eslint.eslintExtensions', (newExts) =>
+      @extensions = newExts
+
   destroy: ->
     atom.config.unobserve 'linter-eslint.eslintRulesDir'
+    atom.config.unobserve 'linter-eslint.eslintExtensions'
 
 module.exports = LinterESLint

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/init",
   "linter-package": true,
   "activationEvents": [],
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Lint JavaScript on the fly, using ESLint",
   "repository": "https://github.com/AtomLinter/linter-eslint.git",
   "license": "MIT",
@@ -11,6 +11,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.9.2"
+    "eslint": "^0.10.0"
   }
 }


### PR DESCRIPTION
This is currently not useful! It just adds an option.

(It does not change the linter’s `@syntax` property. It also does not contain any code to tell `linter` to reload this linter and apply it to other file types.)