### PR TITLE
Make path to executable configurable

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -2,12 +2,16 @@ path = require 'path'
 
 module.exports =
   config:
-    eslintRulesDir:
+    eslintExecutablePath:
       type: 'string'
-      default: ''
+      default: path.join __dirname, '..', 'node_modules', 'eslint', 'bin'
     disableWhenNoEslintrcFileInPath:
       type: 'boolean'
       default: false
+    eslintRulesDir:
+      description: 'Relative to working directory'
+      type: 'string'
+      default: ''
 
   activate: ->
     console.log 'activate linter-eslint'


### PR DESCRIPTION
I wanted to try out the `es6jsx` branch on eslint, but I was unable to figure out how to patch in a configurable executable path without removing your custom `lintfile()`.

This pull request uses the base linter logic of Atom Linter instead of the previous custom `lintFile` method, and includes a new option for configuring the path to the `eslint` executable.