### PR TITLE
Upgrade to eslint 0.13.0

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -13,7 +13,7 @@ CLIEngine = eslint.CLIEngine
 class LinterESLint extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.js']
+  @syntax: ['source.js', 'source.js.jsx']
 
   @disableWhenNoEslintrcFileInPath = false
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.10.1"
+    "eslint": "^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.12.0"
+    "eslint": "^0.13.0"
   }
 }


### PR DESCRIPTION
ESLint 0.13.0 added support for JSX and some ES6 features. This is important because it obsoletes JSXHint which is soon going to be sunset.