### PR TITLE
Support predefined Meteor globals (update eslint dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.13.0"
+    "eslint": "^0.14.0"
   }
 }


### PR DESCRIPTION
Update to eslint `^0.14.0`, which adds predefined [Meteor](http://meteor.com) globals.