### PR TITLE
Use resolve to locate a local version of eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Linter package must be installed in order to use this plugin. If Linter is not i
 $ apm install linter-eslint
 ```
 
+linter-eslint will look for a version of eslint local to your project and use it if it's available. If none is found it will fall back to the version it ships with.
+
+Lets say you depend on a specific version of eslint, maybe it has unreleased features, maybe it's just newer than what linter-eslint ships with. If `your-project/node_modules/eslint` exists linter-eslint will try to use that.
+
 ## Settings
 You can configure linter-eslint by editing ~/.atom/config.cson (choose Open Your Config in Atom menu) or in Preferences:
 

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -1,14 +1,10 @@
 linterPath = atom.packages.getLoadedPackage('linter').path
 Linter = require "#{linterPath}/lib/linter"
 findFile = require "#{linterPath}/lib/util"
+resolve = require('resolve').sync
 
 path = require "path"
 fs = require "fs"
-
-eslint = require "eslint"
-linter = eslint.linter
-CLIEngine = eslint.CLIEngine
-
 
 class LinterESLint extends Linter
   # The syntax that the linter handles. May be a string or
@@ -19,10 +15,21 @@ class LinterESLint extends Linter
 
   linterName: 'eslint'
 
+  _requireEsLint: (filePath) ->
+    try
+      eslintPath = resolve('eslint', {
+        basedir: path.dirname(filePath)
+      })
+      return require(eslintPath)
+    # Fall back to the version packaged in linster-eslint
+    return require('eslint')
+
   lintFile: (filePath, callback) ->
+
     filename = path.basename filePath
     origPath = path.join @cwd, filename
     options = {}
+    { linter, CLIEngine } = @_requireEsLint(origPath)
 
     eslintrc = findFile(origPath, '.eslintrc')
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.14.0"
+    "eslint": "^0.14.0",
+    "resolve": "^1.1.5"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/AtomLinter/linter-eslint/issues/21
Fixes https://github.com/AtomLinter/linter-eslint/issues/26

[resolve](https://www.npmjs.com/package/resolve)
> implements the node require.resolve() algorithm such that you can require.resolve() on behalf of a file asynchronously and synchronously

This branch will find and load the eslint that is local to the project you're working on if it's available. If none is found it just falls back to the one packaged in `linter-eslint`. I did notice that it doesn't find a globally installed eslint. I'm new to Atom, but I suspect it's because this this runs from inside atom instead of from node.

This is the same technique that [grunt-cli](https://github.com/gruntjs/grunt-cli/blob/master/bin/grunt#L33) uses to load your local version of grunt, and I adopted it for [CoffeeLint](https://github.com/clutchski/coffeelint/blob/master/bin/coffeelint#L29)