### PR TITLE
Improve messaging for fatal errors

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -62,12 +62,16 @@ class LinterESLint extends Linter
     result = linter.verify @editor.getText(), config
 
     messages = result.map (m) =>
+      message = m.message
+      if m.ruleId?
+        message += " (#{m.ruleId})"
+
       @createMessage {
         line: m.line,
         col: m.column,
         error: m.severity is 2,
         warning: m.severity is 1,
-        message: "#{m.message} (#{m.ruleId})"
+        message: message
       }
 
     callback(messages)


### PR DESCRIPTION
If you use any of the new es6 syntax that isn't supported by eslint (or isn't turned on) you get a confusing looking message like `Unexpected reserved word (undefined)`. It took me a few times seeing that to figure out what that `undefined` was all about.
