### PR TITLE
allows for linting of *.jsx files instead of *.js.jsx

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -9,7 +9,7 @@ fs = require "fs"
 class LinterESLint extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.js', 'source.js.jsx']
+  @syntax: ['source.js', 'source.jsx']
 
   @disableWhenNoEslintrcFileInPath = false
 


### PR DESCRIPTION
Fixes support for *.jsx files as ESLint now supports it.