### PR TITLE
Fixing issue #54; Config.unobserve is deprecated.

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -104,13 +104,13 @@ class LinterESLint extends Linter
   constructor: (editor) ->
     super(editor)
 
-    atom.config.observe 'linter-eslint.eslintRulesDir', (newDir) =>
+    @rulesDirListener = atom.config.observe 'linter-eslint.eslintRulesDir', (newDir) =>
       @rulesDir = newDir
 
     atom.config.observe 'linter-eslint.disableWhenNoEslintrcFileInPath', (skipNonEslint) =>
       @disableWhenNoEslintrcFileInPath = skipNonEslint
 
   destroy: ->
-    atom.config.unobserve 'linter-eslint.eslintRulesDir'
+    @rulesDirListener.dispose()
 
 module.exports = LinterESLint


### PR DESCRIPTION
Fixing issue #54 according to deprecation message:

> Config::unobserve no longer does anything. Call .dispose() on the object returned by Config::observe instead.
