### PR TITLE
upgrading to eslint 0.18.0. Resolves AtomLinter/linter-eslint#50

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.17.1",
+    "eslint": "^0.18.0",
     "resolve": "^1.1.5"
   }
 }


### PR DESCRIPTION
Fixes error with `space-before-function-paren` that was added in the release on March 28. 

This fix resolved the error I was having locally