### PR TITLE
Use activationCommands instead of activationEvents.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-eslint",
   "main": "./lib/init",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": [],
   "version": "0.5.1",
   "description": "Lint JavaScript on the fly, using ESLint",
   "repository": "https://github.com/AtomLinter/linter-eslint.git",


### PR DESCRIPTION
Kills a Deprecation Cop warning.

activationEvents has been deprecated since v0.153.0:
https://github.com/atom/atom/commit/53b538311e85b2539e8709ef8dd44d8ab74e
9bab