### PR TITLE
Add support for globally installed eslint, engines and plugins

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -11,7 +11,7 @@ fs = require "fs"
 class LinterESLint extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.js', 'source.js.jsx']
+  @syntax: ['source.js', 'source.js.jsx', 'source.babel']
 
   @disableWhenNoEslintrcFileInPath = false
 

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -20,7 +20,8 @@ class LinterESLint extends Linter
   _findGlobalNpmDir: () ->
     exec 'npm config get prefix', (code, stdout, stderr) =>
       if not stderr
-        dir = stdout.replace(/[\n\r\t]/g, '') + '/lib/node_modules'
+        cleanPath = stdout.replace(/[\n\r\t]/g, '')
+        dir = path.join(cleanPath, 'lib', 'node_modules')
         fs.exists dir, (exists) =>
           if exists
             @npmPath = dir

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -3,6 +3,7 @@ Linter = require "#{linterPath}/lib/linter"
 findFile = require "#{linterPath}/lib/util"
 resolve = require('resolve').sync
 {allowUnsafeNewFunction} = require 'loophole'
+{exec} = require 'child_process'
 
 path = require "path"
 fs = require "fs"
@@ -16,6 +17,14 @@ class LinterESLint extends Linter
 
   linterName: 'eslint'
 
+  _findGlobalNpmDir: () ->
+    exec 'npm config get prefix', (code, stdout, stderr) =>
+      if not stderr
+        dir = stdout.replace(/[\n\r\t]/g, '') + '/lib/node_modules'
+        fs.exists dir, (exists) =>
+          if exists
+            @npmPath = dir
+
   _requireEsLint: (filePath) ->
     @localEslint = false
     try
@@ -25,6 +34,14 @@ class LinterESLint extends Linter
       eslint = require(eslintPath)
       @localEslint = true
       return eslint
+    catch
+      try
+        eslintPath = resolve('eslint', {
+          basedir: @npmPath
+        })
+        eslint = require(eslintPath)
+        @localEslint = true
+        return eslint
     # Fall back to the version packaged in linster-eslint
     return require('eslint')
 
@@ -115,6 +132,8 @@ class LinterESLint extends Linter
 
     atom.config.observe 'linter-eslint.disableWhenNoEslintrcFileInPath', (skipNonEslint) =>
       @disableWhenNoEslintrcFileInPath = skipNonEslint
+
+    @_findGlobalNpmDir()
 
   destroy: ->
     @rulesDirListener.dispose()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/init",
   "linter-package": true,
   "activationCommands": [],
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Lint JavaScript on the fly, using ESLint",
   "repository": "https://github.com/AtomLinter/linter-eslint.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "eslint": "^0.20.0",
+    "eslint": "^0.21.0",
     "loophole": "^1.0.0",
     "resolve": "^1.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/init",
   "linter-package": true,
   "activationCommands": [],
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Lint JavaScript on the fly, using ESLint",
   "repository": "https://github.com/AtomLinter/linter-eslint.git",
   "license": "MIT",


### PR DESCRIPTION
I'd added some code to get global npm node_modules folder and try to load eslint, engines and plugins from there. This addresses issue #35 in a better way (IMO) since there's no need to install same packages to every repo you code in. They can now just be installed globally and linter-eslint will fall back to them if no local ones found.