### PR TITLE
Fix for eslint@0.21. Use addPlugin() method.

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -25,7 +25,7 @@ class LinterESLint extends Linter
       eslint = require(eslintPath)
       @localEslint = true
       return eslint
-    # Fall back to the version packaged in linster-eslint
+    # Fall back to the version packaged in linter-eslint
     return require('eslint')
 
   lintFile: (filePath, callback) ->
@@ -60,17 +60,34 @@ class LinterESLint extends Linter
 
     config = engine.getConfigForFile(origPath)
 
-    # This sidesteps a chicken and egg problem:
-    # CLIEngine contains loadPlugins() that is not exposed, so we can't call it
-    # directly. The plugins need to be passed into CLIEngine, but we don't know
-    # which plugins are loaded until after we load CLIEngine.
-    #
-    # If you are loading plugins this will replace the existing engine with a
-    # new engine where we can pass in the set of plugins for it to load.
+    notFullyCompatible = false
+    notFoundPlugins = []
     if config.plugins?.length
       if @localEslint
-        options.plugins = config.plugins
-        engine = new CLIEngine(options)
+        unless engine.addPlugin
+          # we have an old version `eslint@0.20` or less
+          notFullyCompatible = true
+          # This sidesteps a chicken and egg problem:
+          # CLIEngine contains loadPlugins() that is not exposed, so we can't call it
+          # directly. The plugins need to be passed into CLIEngine, but we don't know
+          # which plugins are loaded until after we load CLIEngine.
+          #
+          # If you are loading plugins this will replace the existing engine with a
+          # new engine where we can pass in the set of plugins for it to load.
+          options.plugins = config.plugins
+          engine = new CLIEngine(options)
+        else
+          # we have `eslint@0.21`+
+          config.plugins.forEach (pluginName) ->
+            npmPluginName = 'eslint-plugin-' + pluginName
+            try
+              pluginPath = resolve(npmPluginName, {
+                basedir: path.dirname(origPath)
+              })
+              pluginObject = require(pluginPath)
+              engine.addPlugin(npmPluginName, pluginObject)
+            catch
+              notFoundPlugins.push(npmPluginName)
       else
         isPluginRule = new RegExp("^(#{config.plugins.join('|')})/")
         Object.keys(config.rules).forEach (key) ->
@@ -79,9 +96,18 @@ class LinterESLint extends Linter
     # wrap `eslint()` into `allowUnsafeNewFunction`
     # https://discuss.atom.io/t/--template-causes-unsafe-eval-error/9310
     # https://github.com/babel/babel/blob/master/src/acorn/src/identifier.js#L46
-    result = null
-    allowUnsafeNewFunction =>
-      result = linter.verify @editor.getText(), config
+    result = []
+    if notFoundPlugins.length
+      result.push({
+        line: 1
+        column: 0
+        severity: 1
+        message: "`npm install #{notFoundPlugins.join(' ')}`
+        in your project (linter-eslint)"
+      })
+    else
+      allowUnsafeNewFunction =>
+        result = linter.verify @editor.getText(), config
 
     if config.plugins?.length and not @localEslint
       result.push({
@@ -90,6 +116,15 @@ class LinterESLint extends Linter
         severity: 1
         message: "`npm install eslint` in your project to enable plugins:
         #{config.plugins.join(', ')} (linter-eslint)"
+      })
+
+    if notFullyCompatible
+      result.push({
+        line: 1
+        column: 0
+        severity: 1
+        message: "You are using the version of eslint@0.20 or less.
+        You have to update eslint to 0.21+ or downgrade linter-eslint"
       })
 
     messages = result.map (m) =>


### PR DESCRIPTION
Fixes #74 and have to fix #72 also.

It needs somewhere to warn users about the versin `linter-eslint` with this patch
works only with `eslint@0.21`+
