### PR TITLE
Pass current filename to eslint to enable `context.getFilename()`

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -126,7 +126,7 @@ class LinterESLint extends Linter
       # https://discuss.atom.io/t/--template-causes-unsafe-eval-error/9310
       # https://github.com/babel/babel/blob/master/src/acorn/src/identifier.js#L46
       allowUnsafeNewFunction =>
-        result = linter.verify @editor.getText(), config
+        result = linter.verify @editor.getText(), config, @editor.getPath()
 
     if config.plugins?.length and not @localEslint
       result.push({


### PR DESCRIPTION
Similar issue to https://github.com/roadhump/SublimeLinter-eslint/issues/40

ESLint supports passing filenames in `linter.verify` (http://eslint.org/docs/developer-guide/nodejs-api). It will allow eslint plugins to use `context.getFilename()`.