### PR TITLE
Adds semantic javascript to supported grammars

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -33,7 +33,7 @@ module.exports =
 
   provideLinter: ->
     provider =
-      grammarScopes: ['source.js', 'source.js.jsx', 'source.babel']
+      grammarScopes: ['source.js', 'source.js.jsx', 'source.babel', 'source.js-semantic']
       scope: 'file'
       lintOnFly: true
       lint: (TextEditor) =>


### PR DESCRIPTION
Many people use the [language-javascript-semantic](https://github.com/p-e-w/language-javascript-semantic) package in combination with this linter plugin. If we could have baked in support for the grammar in this plugin it would save the hassle of having to re-add it whenever the plugin updates.