### PR TITLE
Fix loading plugins while using global npm path

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -80,7 +80,8 @@ module.exports =
 
             # `eslint >= 0.21.0`
             if engine.addPlugin
-              config.plugins.forEach(@loadPlugin.bind(this, engine, origPath))
+              pluginPath = if @useGlobalEslint then @npmPath else origPath
+              config.plugins.forEach(@loadPlugin.bind(this, engine, pluginPath))
             else
               options.plugins = config.plugins
               engine = new CLIEngine(options)


### PR DESCRIPTION
Current version does not loads plugins from global packages properly. This PR fixes this problem.