### PR TITLE
Add config option to show eslint ruleid in messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ You can configure linter-eslint by editing ~/.atom/config.cson (choose Open Your
 'linter-eslint':
   'eslintRulesDir': 'mydir'
   'disableWhenNoEslintrcFileInPath': true  
-  'useGlobalEslint': true
+  'useGlobalEslint': true,
+  'showRuleIdInMessage': true
 ```
 
 The `eslintRulesDir` is relative to the working directory (project root).
 `disableWhenNoEslintrcFileInPath` allows disabling linter-eslint when there is no `.eslintrc` file in the path.
 `useGlobalEslint` allows using globally installed eslint and plugins for it.
+Setting `showRuleIdInMessage` to `true` will append the eslint ruleId to warning/error messages.
 
 
 ## Contributing

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -23,6 +23,9 @@ module.exports =
     useGlobalEslint:
       type: 'boolean'
       default: false
+    showRuleIdInMessage:
+      type: 'boolean'
+      default: false
 
   activate: ->
     console.log 'activate linter-eslint'
@@ -60,6 +63,9 @@ module.exports =
         rulesDir = atom.config.get 'linter-eslint.eslintRulesDir'
         rulesDir = findFile(origPath, [rulesDir], false, 0) if rulesDir
 
+        # Add showRuleId option
+        showRuleId = atom.config.get 'linter-eslint.showRuleIdInMessage'
+
         if rulesDir and fs.existsSync rulesDir
           options.rulePaths = [rulesDir]
 
@@ -95,7 +101,7 @@ module.exports =
             allowUnsafeNewFunction ->
               results = linter
                 .verify TextEditor.getText(), config, filePath
-                .map ({message, line, severity}) ->
+                .map ({message, line, severity, ruleId}) ->
 
                   # Calculate range to make the error whole line
                   # without the indentation at begining of line
@@ -104,12 +110,20 @@ module.exports =
                   endCol = TextEditor.getBuffer().lineLengthForRow line - 1
                   range = [[line - 1, startCol], [line - 1, endCol]]
 
-                  {
-                    type: if severity is 1 then 'warning' else 'error'
-                    text: message
-                    filePath: filePath
-                    range: range
-                  }
+                  if showRuleId
+                    {
+                      type: if severity is 1 then 'warning' else 'error'
+                      html: '<span class="badge badge-flexible">' + ruleId + '</span> ' + message
+                      filePath: filePath
+                      range: range
+                    }
+                  else
+                    {
+                      type: if severity is 1 then 'warning' else 'error'
+                      text: message
+                      filePath: filePath
+                      range: range
+                    }
 
             results
 


### PR DESCRIPTION
I have added a config option 'showRuleIdInMessage', that when set to
true will add the corresponding eslint rule id to warning/error
messages. Config option is default false.