### PR TITLE
Fix "fs is not defined" on linting

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -1,7 +1,7 @@
 path = require 'path'
 {sync} = require 'resolve'
 {execSync} = require 'child_process'
-{statSync, existsSync} = require 'fs'
+{statSync} = require 'fs'
 {CompositeDisposable} = require 'atom'
 {allowUnsafeNewFunction} = require 'loophole'
 
@@ -72,7 +72,7 @@ module.exports =
         # Add showRuleId option
         showRuleId = atom.config.get 'linter-eslint.showRuleIdInMessage'
 
-        if rulesDir and existsSync rulesDir
+        if rulesDir and statSync(rulesDir).isDirectory()
           options.rulePaths = [rulesDir]
 
         # `linter` and `CLIEngine` comes from `eslint` module

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -72,8 +72,13 @@ module.exports =
         # Add showRuleId option
         showRuleId = atom.config.get 'linter-eslint.showRuleIdInMessage'
 
-        if rulesDir and statSync(rulesDir).isDirectory()
-          options.rulePaths = [rulesDir]
+        if rulesDir
+          try
+            if statSync(rulesDir).isDirectory()
+              options.rulePaths = [rulesDir]
+          catch error
+            console.warn '[Linter-ESLint] ESlint rules direcotory does not exist in your fs'
+            console.warn error.message
 
         # `linter` and `CLIEngine` comes from `eslint` module
         {linter, CLIEngine} = @requireESLint filePath

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -1,7 +1,7 @@
 path = require 'path'
 {sync} = require 'resolve'
 {execSync} = require 'child_process'
-{statSync} = require 'fs'
+{statSync, existsSync} = require 'fs'
 {CompositeDisposable} = require 'atom'
 {allowUnsafeNewFunction} = require 'loophole'
 
@@ -72,7 +72,7 @@ module.exports =
         # Add showRuleId option
         showRuleId = atom.config.get 'linter-eslint.showRuleIdInMessage'
 
-        if rulesDir and fs.existsSync rulesDir
+        if rulesDir and existsSync rulesDir
           options.rulePaths = [rulesDir]
 
         # `linter` and `CLIEngine` comes from `eslint` module


### PR DESCRIPTION
Hi, you use `fs` package on [L75](https://github.com/AtomLinter/linter-eslint/blob/master/lib/linter-eslint.coffee#L75) and it not properly requered, so i get "fs is not defined" error.