### PR TITLE
Search for eslint in parent directories and fix `this.binary` caching

### DIFF
--- a/lib/linter-eslint.js
+++ b/lib/linter-eslint.js
@@ -50,14 +50,18 @@ export default {
   },
 
   findESLint(cwd) {
-    return new Promise(function (resolve) {
+    return new Promise(resolve => {
       // Return cached copy of binary path
       if (this.binary) return resolve(this.binary)
 
-      // Try to find ESLint binary localy and globaly
-      return which('eslint', {cwd}, function (error, eslint) {
+      // Try to find ESLint binary locally and globally
+      return which('eslint', {cwd}, (error, eslint) => {
         eslint = eslint || atom.config.get('linter-eslint.eslintPath')
         eslint = eslint.trim()
+
+        // Recursively search the parent directory until we reach the root
+        const parent = path.dirname(cwd)
+        if (!eslint && parent !== cwd) return this.findESLint(parent)
 
         this.binary = eslint
         return resolve(eslint)


### PR DESCRIPTION
This tells linter-eslint to recursively search parent directories for the eslint binary. This supports projects that share a eslint configuration between multiple subprojects:

```
.
├── Client
│   ├── client.js
│   └── package.json
├── Server
│   ├── server.js
│   └── package.json
└── package.json  # eslint, babel-eslint, eslint-plugins here
```

With this commit, if you open up the Client or Server directory in Atom, linter-eslint will find eslint in the parent directory's node_modules.

There was also a bug where setting `this.binary` would add a property to the global object instead of the exports, since `findESLint` was using unbound functions. Switched to arrow functions to fix this.