### PR TITLE
Handle error parsing file

### DIFF
--- a/lib/linter-eslint.js
+++ b/lib/linter-eslint.js
@@ -118,6 +118,9 @@ export default {
 
     // Return issues formatted for base `Linter`
     return messages.map(function ({line = 1, message, severity, ruleId}) {
+      // There was a problem parsing the file
+      if (line === 0) { throw new Error(message) }
+
       const indentLevel = TextEditor.indentationForBufferRow(line - 1)
       const startCol = TextEditor.getTabLength() * indentLevel
       const endCol = TextEditor.getBuffer().lineLengthForRow(line - 1)


### PR DESCRIPTION
Addresses #146 by displaying nicer error message to user when line is 0.

This:
<img width="472" alt="screen shot 2015-07-10 at 1 36 37 am" src="https://cloud.githubusercontent.com/assets/3619060/8615065/638e0bce-26a4-11e5-9f9c-837130ca2f7b.png">

Becomes:
<img width="471" alt="screen shot 2015-07-10 at 1 38 11 am" src="https://cloud.githubusercontent.com/assets/3619060/8615069/6d9043ee-26a4-11e5-81a4-28c9f413f566.png">

