### PR TITLE
[2.3.0 on Windows] .eslintignore not being honored

### DIFF
--- a/lib/linter-eslint.js
+++ b/lib/linter-eslint.js
@@ -96,7 +96,7 @@ export default {
     // Find ESLint, first try to match
     // locally installed ESLint if option isn't disabled
     let cwd = findFile(filePath, 'node_modules')
-    cwd = this.findProjectPath(filePath) || (cwd && path.resolve(cwd, '..')) || '/'
+    cwd = this.findProjectPath(filePath) || (cwd && path.resolve(cwd, '..')) || path.sep
     let eslint = await this.findESLint(cwd)
 
     // We didn't find ESLint binary
@@ -109,8 +109,8 @@ export default {
     }
 
     // Remove `cwd` from filePath
-    params.push('--stdin-filename', filePath.replace(`${cwd}/`, ''))
-    if (config) params = [...params, '--config', config.replace(`${cwd}/`, '')]
+    params.push('--stdin-filename', filePath.replace(cwd + path.sep, ''))
+    if (config) params = [...params, '--config', config.replace(cwd + path.sep, '')]
 
     // Push default params after added additional ones
     params = [...params, ...defaultParams]


### PR DESCRIPTION
This PR ensures the correct platform path separators are used.

Using incorrect separators causes at least [these lines](https://github.com/AtomLinter/linter-eslint/blob/master/lib/linter-eslint.js#L112-L113) to not replace the `cwd` from the file path and therefore on Windows `linter-eslint` always passes the full path to ESLint causing `.eslintignore` logic to fail.