### PR TITLE
add 'Show File Ignored Warning' option

### DIFF
--- a/lib/linter-eslint.js
+++ b/lib/linter-eslint.js
@@ -21,6 +21,11 @@ export default {
       default: true,
       description: 'Show the `ESlint` rule before the issue message'
     },
+    showFileIgnoredWarning: {
+      type: 'boolean',
+      default: false,
+      description: 'Show "File ignored because of your .eslintignore file. Use --no-ignore to override." warning'
+    },
     disableWhenNoEslintrcFileInPath: {
       type: 'boolean',
       default: false,
@@ -138,6 +143,11 @@ export default {
       try {
         results = JSON.parse(output).results
         messages = results[0].messages || []
+        // clobber ignored message based on settings
+        if (messages.length === 1 && !!~messages[0].message.indexOf('ignored because of your .eslintignore file') &&
+            !atom.config.get('linter-eslint.showFileIgnoredWarning')) {
+          messages = []
+        }
       } catch (error) {
         console.warn('[Linter-ESLint] error while parsing ouput:')
         console.warn(output)


### PR DESCRIPTION
@iam4x, I've added an option to hide the annoying **_File ignored because of your .eslintignore file. Use --no-ignore to override._**  warning message for files ignored in the `.eslintignore` file.

Since I didn't raise an issue yet please feel free to close this if this option is not what you want in `linter-eslint` :)