### PR TITLE
Search up the directory hierarchy for the local copy of eslint

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -184,8 +184,7 @@ module.exports =
   requireESLint: (filePath) ->
     @localEslint = false
     try
-      eslintPath = sync 'eslint', {basedir: path.dirname(filePath)}
-      eslint = require eslintPath
+      eslint = @requireLocalESLint filePath
       @localEslint = true
       return eslint
     catch error
@@ -207,6 +206,18 @@ module.exports =
 
     # Fall back to the version packaged in linter-eslint
     return require('eslint')
+
+  requireLocalESLint: (filePath) ->
+    # Traverse up the directory hierarchy until the root
+    currentPath = filePath
+    until currentPath is path.dirname currentPath
+      currentPath = path.dirname currentPath
+      try
+        eslintPath = sync 'eslint', {basedir: currentPath}
+      catch
+        continue
+      return require eslintPath
+    throw new Error "Could not find `eslint` locally installed in #{ path.dirname filePath } or any parent directories"
 
   findGlobalNPMdir: ->
     try


### PR DESCRIPTION
This lets users open up subdirectories of their project and still use their project's copy of eslint. For example:

```
project/
  subdir/
    src.js
  node_modules/
    eslint/
```

If you open `subdir` in Atom, linter-eslint will now load `project/node_modules/eslint`.