### PR TITLE
Wrap `require('eslint')` in `allowUnsafeNewFunction`

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -189,7 +189,7 @@ module.exports =
       if @useGlobalEslint
         try
           eslintPath = sync 'eslint', {basedir: @npmPath}
-          eslint = require eslintPath
+          eslint = allowUnsafeNewFunction -> require eslintPath
           @localEslint = true
           return eslint
       else
@@ -214,7 +214,7 @@ module.exports =
         eslintPath = sync 'eslint', {basedir: currentPath}
       catch
         continue
-      return require eslintPath
+      return allowUnsafeNewFunction -> require eslintPath
     throw new Error "Could not find `eslint` locally installed in #{ path.dirname filePath } or any parent directories"
 
   findGlobalNPMdir: ->


### PR DESCRIPTION
eslint 1.0.0-rc-2 uses `Function` inside one of its dependencies. This causes an error in Atom because Atom uses CSP to prevent `Function` from working. To work around this, we need to use `loophole.allowUnsafeNewFunction` once a PR I submitted to `loophole` is merged.

Partly fixes #177.