### PR TITLE
Update `loophole` to 1.1.0 so that it works with eslint 1.0.0-rc-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "atom-linter": "^2.0.1",
     "eslint": "^0.24.0",
-    "loophole": "^1.0.0",
+    "loophole": "^1.1.0",
     "resolve": "^1.1.5"
   },
   "providedServices": {


### PR DESCRIPTION
This makes sure that all users of linter-eslint are using loophole 1.1.0 which works with eslint 1.0 RC2.