### PR TITLE
Add option to select file extensions

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -31,6 +31,15 @@ module.exports =
       type: 'string'
       default: ''
       description: 'Run `$ npm config get prefix` to find it'
+    fileScopes:
+      type: 'string'
+      default: 'source.js,source.js.jsx,source.babel,source.js-semantic',
+      description: 'Lint files with these scopes (passed to atom-linter) (separated by commas)'
+    fileExtensions:
+      type: 'string'
+      default: '.js,.js.jsx,.babel,.js-semantic',
+      description: 'Lint files with these file extensions (separated by commas)'
+
 
   activate: ->
     console.log 'activate linter-eslint'
@@ -44,7 +53,7 @@ module.exports =
 
   provideLinter: ->
     provider =
-      grammarScopes: ['source.js', 'source.js.jsx', 'source.babel', 'source.js-semantic']
+      grammarScopes: atom.config.get('linter-eslint.fileScopes').split(',')
       scope: 'file'
       lintOnFly: true
       lint: (TextEditor) =>
@@ -77,6 +86,9 @@ module.exports =
           catch error
             console.warn '[Linter-ESLint] ESlint rules directory does not exist in your fs'
             console.warn error.message
+
+        # Add file extensions option
+        options.extnensions = atom.config.get('linter-eslint.fileExtensions').split(',')
 
         # `linter` and `CLIEngine` comes from `eslint` module
         {linter, CLIEngine} = @requireESLint filePath


### PR DESCRIPTION
I haven't changed the readme yet because I want to get feedback on the best way to name/describe the options. My specific problem is I want to lint `.js.erb` files, but the `grammarScope` I need to add is `source.js.rails source.js.jquery` (don't ask me why). So that's why I've included both options, but I don't know how confusing that might be, so any feedback is appreciated.