### PR TITLE
Use column reported by eslint for error location

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -110,12 +110,17 @@ module.exports =
               results = linter
                 .verify TextEditor.getText(), config, filePath
                 .map ({message, line, severity, ruleId}) ->
-
                   # Calculate range to make the error whole line
                   # without the indentation at begining of line
                   indentLevel = TextEditor.indentationForBufferRow line - 1
-                  startCol = TextEditor.getTabLength() * indentLevel
+                  startOfLine = TextEditor.getTabLength() * indentLevel
+
                   endCol = TextEditor.getBuffer().lineLengthForRow line - 1
+                  startCol = if (column >= endCol) or (column < startOfLine)
+                      startOfLine
+                    else
+                      column
+
                   range = [[line - 1, startCol], [line - 1, endCol]]
 
                   if showRuleId


### PR DESCRIPTION
Previously, linter-eslint would report all message sources (locations in your code causing errors or warnings, as reported by eslint) as being located at the start of the line (adjusted for indention) and continuing through the end of the line. This made it easy to see lines with errors, and was an easy design decision since eslint reports only the start column for message sources, not the end column.

However, this made it harder to use linter messages since it would always report the message source as the same column, and clicking the message would take you to the start of the source line.

This commit changes linter-eslint to report message source locations as beginning at the column that eslint says the error/warning is coming from, and continuing to the end of the line. This still isn't 100% correct ('continuing to the end of the line' is a pretty inelegant hack), but is more correct than before. There's also some logic to use the old behavior (highlight all the text on the line) if the range would be 0, or the message location reported by eslint is before the beginning of text on the line.