### PR TITLE
Lint javascript inside HTML file

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -94,13 +94,8 @@ module.exports =
 
           # We have plugins to load
           if config.plugins
+            config.plugins.forEach(@loadPlugin.bind(this, engine, filePath))
 
-            # `eslint >= 0.21.0`
-            if engine.addPlugin
-              config.plugins.forEach(@loadPlugin.bind(this, engine, filePath))
-            else
-              options.plugins = config.plugins
-              engine = new CLIEngine(options)
 
           try
             results = []

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": "^2.0.1",
-    "eslint": "^0.24.0",
+    "atom-linter": "^3.3.0",
+    "atom-package-deps": "^2.1.3",
+    "eslint": "^1.7.3",
+    "eslint-plugin-html": "^1.0.4",
     "loophole": "^1.1.0",
-    "resolve": "^1.1.5",
-    "atom-package-deps": "^2.1.3"
+    "resolve": "^1.1.5"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
#194 Use [executeOnText](http://eslint.org/docs/developer-guide/nodejs-api.html#executeontext) instead of [linter](http://eslint.org/docs/developer-guide/nodejs-api.html#linter) because `linter` does not support [plugin](https://github.com/BenoitZugmeyer/eslint-plugin-html)