### PR TITLE
Auto install linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
 # linter-eslint
 
-This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [eslint](http://eslint.org). It will be used with files that have the “JavaScript” syntax.
+This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides
+an interface to [eslint](http://eslint.org). It will be used with files that
+have the “JavaScript” syntax.
 
 ## Installation
-Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
+```ShellSession
+apm install linter-eslint
+```
 
-### Package installation
+`linter-eslint` will look for a version of `eslint` local to your project and
+use it if it's available. If none is found it will fall back to the version it
+ships with.
 
-* `$ apm install linter-eslint`
+Lets say you depend on a specific version of `eslint`, maybe it has unreleased
+features, maybe it's just newer than what linter-eslint ships with. If
+`your-project/node_modules/eslint` exists `linter-eslint` will be used.
 
-`linter-eslint` will look for a version of `eslint` local to your project and use it if it's available. If none is found it will fall back to the version it ships with.
-
-Lets say you depend on a specific version of `eslint`, maybe it has unreleased features, maybe it's just newer than what linter-eslint ships with. If `your-project/node_modules/eslint` exists `linter-eslint` will be used.
+Note that if you do not have the `linter` package installed it will be installed
+for you. If you are using an alternative `linter-*` consumer feel free to disable
+the `linter` package.
 
 ## Use with plugins
 
@@ -19,7 +27,6 @@ You have two options:
 
 * Install locally to your project `eslint` and the plugin
   * `$ npm i --save-dev eslint [eslint-plugins]`
-
 
 * Install globaly `eslint` and plugins
   * `$ npm i -g eslint [eslint-plugins]`
@@ -30,7 +37,7 @@ You have two options:
 
 You can configure linter-eslint by editing ~/.atom/config.cson (choose Open Your Config in Atom menu) or in Preferences:
 
-```coffee
+```cson
 'linter-eslint':
   'eslintRulesDir': 'mydir'
   'disableWhenNoEslintrcFileInPath': true
@@ -50,16 +57,16 @@ You can configure linter-eslint by editing ~/.atom/config.cson (choose Open Your
 
 If you would like to contribute enhancements or fixes, please do the following:
 
-* Fork the plugin repository
-* Hack on a separate topic branch created from the latest `master`
-* Commit and push the topic branch
-* Make a pull request
-* Welcome to the club
+0. Fork the plugin repository
+0. Hack on a separate topic branch created from the latest `master`
+0. Commit and push the topic branch
+0. Make a pull request
+0. Welcome to the club!
 
 Please note that modifications should follow these coding guidelines:
 
 * Indent is 2 spaces
-* Code should pass `coffeelint` linter
+* Code should pass `coffeelint` linter with the provided `coffeelint.json`
 * Vertical whitespace helps readability, don’t be afraid to use it
 
 Thank you for helping out!

--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -6,10 +6,6 @@ path = require 'path'
 {CompositeDisposable} = require 'atom'
 {allowUnsafeNewFunction} = require 'loophole'
 
-linterPackage = atom.packages.getLoadedPackage 'linter'
-unless linterPackage
-  return atom.notifications.addError 'Linter should be installed first, `apm install linter`', dismissable: true
-
 module.exports =
   config:
     eslintRulesDir:
@@ -33,6 +29,7 @@ module.exports =
       description: 'Run `$ npm config get prefix` to find it'
 
   activate: ->
+    require('atom-package-deps').install('linter-eslint')
     console.log 'activate linter-eslint'
     @subscriptions = new CompositeDisposable
 
@@ -112,7 +109,7 @@ module.exports =
                 .map ({message, line, severity, ruleId, column}) ->
 
                   indentLevel = TextEditor.indentationForBufferRow line - 1
-                  startCol = column || TextEditor.getTabLength() * indentLevel
+                  startCol = column or TextEditor.getTabLength() * indentLevel
                   endOfLine = TextEditor.getBuffer().lineLengthForRow line - 1
                   range = [[line - 1, startCol], [line - 1, endOfLine]]
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,12 @@
     "atom-linter": "^2.0.1",
     "eslint": "^0.24.0",
     "loophole": "^1.1.0",
-    "resolve": "^1.1.5"
+    "resolve": "^1.1.5",
+    "atom-package-deps": "^2.1.3"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Automatically install the `linter` package, if it is not already. Remove the requirement that it be loaded to allow the use of an alternative consumer of this provider.

Closes #207.
Closes #212.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/217)
<!-- Reviewable:end -->
