### PR TITLE
Capitalize types of linter messages

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -116,14 +116,14 @@ module.exports =
 
                   if showRuleId
                     {
-                      type: if severity is 1 then 'warning' else 'error'
+                      type: if severity is 1 then 'Warning' else 'Error'
                       html: '<span class="badge badge-flexible">' + ruleId + '</span> ' + message
                       filePath: filePath
                       range: range
                     }
                   else
                     {
-                      type: if severity is 1 then 'warning' else 'error'
+                      type: if severity is 1 then 'Warning' else 'Error'
                       text: message
                       filePath: filePath
                       range: range
@@ -138,7 +138,7 @@ module.exports =
 
             [
               {
-                type: 'error'
+                type: 'Error'
                 text: 'error while linting file, open the console for more information'
                 file: filePath
                 range: [[0, 0], [0, 0]]


### PR DESCRIPTION
"error" and "warning" should be "Error" and "Warning" as per the official linter spec. (see https://github.com/atom-community/linter/wiki/Linter-API, in particular https://github.com/atom-community/linter/wiki/Registering-Custom-Message-Types)

This doesn't normally matter, but other consumers of the API (at the moment, namely Nuclide's diagnostics plugin) might be sensitive to the distinction.