### PR TITLE
Added text property to errors

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -118,6 +118,7 @@ module.exports =
                     {
                       type: if severity is 1 then 'Warning' else 'Error'
                       html: '<span class="badge badge-flexible">' + ruleId + '</span> ' + message
+                      text: "#{ruleId} - #{message}"
                       filePath: filePath
                       range: range
                     }


### PR DESCRIPTION
Fix for #239.

The linter package will still display the html , but other packages that consume linter messages can choose between using either html or text as shown below.

![image](https://cloud.githubusercontent.com/assets/9221137/10717804/36498f80-7b31-11e5-9175-249fa9e2f875.png)

For the text I made it follow this convention: ruleId - message. Does this work or would you prefer it be formatted in a different way?