### PR TITLE
Revert "Added text property to errors"

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -133,7 +133,6 @@ module.exports =
                     {
                       type: if severity is 1 then 'Warning' else 'Error'
                       html: '<span class="badge badge-flexible">' + ruleId + '</span> ' + message
-                      text: "#{ruleId} - #{message}"
                       filePath: filePath
                       range: range
                     }


### PR DESCRIPTION
Reverts AtomLinter/linter-eslint#240
It's a fatal error in latest linter as it's an abuse of the API
Ref: https://github.com/atom-community/linter/pull/975