### PR TITLE
Fix Error: EPERM: on Windows box

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -238,7 +238,7 @@ module.exports =
 
       # If none, try to find it
       unless globalNodePath
-        globalNodePath = execSync 'npm config get prefix', {encoding: 'utf8'}
+        globalNodePath = execSync 'npm config get prefix', {encoding: 'utf8', stdio: 'pipe'}
         globalNodePath = globalNodePath.replace /[\n\r\t]/g, ''
 
       # Windows specific


### PR DESCRIPTION
`pipe` should be the default option in `execSync`, but it seems it is not the case.

https://nodejs.org/api/child_process.html#child_process_options_stdio

Closes #244 