### PR TITLE
Fix: require internal eslint causes csp eval fail

### DIFF
--- a/lib/linter-eslint.coffee
+++ b/lib/linter-eslint.coffee
@@ -217,7 +217,7 @@ module.exports =
           @warnNotFound = true
 
     # Fall back to the version packaged in linter-eslint
-    return require('eslint')
+    return allowUnsafeNewFunction -> require('eslint')
 
   requireLocalESLint: (filePath) ->
     # Traverse up the directory hierarchy until the root


### PR DESCRIPTION
When the loophole (lib atom plugins use to do eval without triggering CSP errors) wrapper was setup we missed one of the requires (this causes eslint's json validation to generate a new function which fails with an EvalError).

fixes #253

I'm not very good at coffeescript. I hope I did it right!