### PR TITLE
Show a nicer error if spawning NPM fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Upcoming
 
 * Improved error verbosity
+* Show a nice error notification if `npm get prefix` fails
 
 ### v5.0.2
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -52,7 +52,11 @@ Communication.on('JOB', function(job) {
   if (params.global) {
     if (prefixPath === null) {
       const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-      prefixPath = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
+      try {
+        prefixPath = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
+      } catch (e) {
+        throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly')
+      }
     }
     if (process.platform === 'win32') {
       eslintNewPath = Path.join(prefixPath, 'node_modules', 'eslint')


### PR DESCRIPTION
OSX has a problem that applications launched from the Dock do not inherit `$PATH`, so if somebody starts Atom from the Dock instead of Terminal and tries to use the global ESLint, we now show them a nicer notification instead of a confusing trace

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/273)
<!-- Reviewable:end -->
