### PR TITLE
Fix wrong column offset

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -99,7 +99,10 @@ export default {
           nodePath: atom.config.get('linter-eslint.globalNodePath')
         }).then(function(response) {
           return response.map(function({message, line, severity, ruleId, column}) {
-            const range = Helpers.rangeFromLineNumber(textEditor, line - 1)
+            let range = Helpers.rangeFromLineNumber(textEditor, line - 1, column)
+            if (range[0][1] > range[1][1]) {
+                range[1][1] = column
+            }
             if (column) {
               range[0][1] = column - 1
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -99,7 +99,7 @@ export default {
           nodePath: atom.config.get('linter-eslint.globalNodePath')
         }).then(function(response) {
           return response.map(function({message, line, severity, ruleId, column}) {
-            let range = Helpers.rangeFromLineNumber(textEditor, line - 1, column)
+            const range = Helpers.rangeFromLineNumber(textEditor, line - 1, column)
             if (range[0][1] > range[1][1]) {
                 range[1][1] = column
             }


### PR DESCRIPTION
When the column error is the last char of the line, due to `rangeFromLineNumber`, the range is malformed: the start column is greater than the end column.

(Also const values cannot be modified) :)

See #276.