### PR TITLE
Improve code readable about column offset

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -99,12 +99,12 @@ export default {
           nodePath: atom.config.get('linter-eslint.globalNodePath')
         }).then(function(response) {
           return response.map(function({message, line, severity, ruleId, column}) {
-            const range = Helpers.rangeFromLineNumber(textEditor, line - 1, column)
-            if (range[0][1] > range[1][1]) {
-                range[1][1] = column
-            }
+            const range = Helpers.rangeFromLineNumber(textEditor, line - 1)
             if (column) {
               range[0][1] = column - 1
+            }
+            if (column > range[1][1]) {
+              range[1][1] = column - 1
             }
             const ret = {
               filePath: filePath,


### PR DESCRIPTION
The patch makes more sense if I don't use the `colStart` parameter.

Indeed the range, with zero-based column, is returned. 

Then, if the error is in the column past the last char (equals to the length of the line + 1), we need to fix accordingly colEnd (`range[1][1]`).

See #276 and #277