### PR TITLE
Support local and absolute paths for eslint rules dir.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for `.eslintignore`
 * Add `eslintRcPath` config
 * Add `linter-eslint:fix-file` command
+* Support local and absolute paths for eslintRulesDir
 
 ### v5.1.0
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -92,7 +92,11 @@ Communication.on('JOB', function(job) {
       Path.join(__dirname, 'reporter.js')
     ]
     if (params.rulesDir) {
-      argv.push('--rulesdir', params.rulesDir)
+      let rulesDir = params.rulesDir
+      if (!Path.isAbsolute(rulesDir)) {
+        rulesDir = find(params.fileDir, rulesDir)
+      }
+      argv.push('--rulesdir', rulesDir)
     }
     if (configFile !== null) {
       argv.push('--config', configFile)


### PR DESCRIPTION
This enhances the eslint rules dir support to allow absolute paths as well as those relative to the project.