### PR TITLE
Extend resolveEnv support to the configFile path

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -100,7 +100,7 @@ Communication.on('JOB', function(job) {
       argv.push('--rulesdir', rulesDir)
     }
     if (configFile !== null) {
-      argv.push('--config', configFile)
+      argv.push('--config', resolveEnv(configFile))
     }
     argv.push('--stdin-filename', params.filePath)
     process.argv = argv


### PR DESCRIPTION
Tiny change extending @SpainTrain's patch to include the config file path
https://github.com/SpainTrain/linter-eslint/commit/76662cd91ac90ae448faf847fb8173eba8cec19d