### PR TITLE
Use relative file paths if possible

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -11,7 +11,7 @@ const resolveEnv = require('resolve-env')
 const Communication = new CP()
 
 let eslintPath = null
-let eslintPathLocal = Path.join(FS.realpathSync(Path.join(__dirname, '..')), 'node_modules', 'eslint')
+const eslintPathLocal = Path.join(FS.realpathSync(Path.join(__dirname, '..')), 'node_modules', 'eslint')
 let eslint = null
 let prefixPath = null
 
@@ -42,7 +42,8 @@ Communication.on('JOB', function(job) {
     configFile = params.configFile
   }
 
-  let modulesPath = find(params.fileDir, 'node_modules')
+  const modulesPath = find(params.fileDir, 'node_modules')
+  const eslintignoreDir = Path.dirname(find(params.fileDir, '.eslintignore'))
   let eslintNewPath = null
   if (modulesPath) {
     process.env.NODE_PATH = modulesPath
@@ -85,6 +86,7 @@ Communication.on('JOB', function(job) {
   }
 
   job.Response = new Promise(function(resolve) {
+    const filePath = (eslintignoreDir) ? Path.relative(eslintignoreDir, params.filePath) : params.filePath
     const argv = [
       process.execPath,
       eslintPath,
@@ -102,7 +104,7 @@ Communication.on('JOB', function(job) {
     if (configFile !== null) {
       argv.push('--config', configFile)
     }
-    argv.push('--stdin-filename', params.filePath)
+    argv.push('--stdin-filename', filePath)
     process.argv = argv
     eslint.execute(process.argv, params.contents)
     resolve(global.__LINTER_RESPONSE)


### PR DESCRIPTION
`.eslintignore` files must be placed at a project's root, and the patterns within the .eslintignore are relative to project root.  Therefore, for ESLint to know whether a file should be ignored, one of two things must be true:

1. The .eslintignore entries need to be in the format `**/foo.js`
2. The paths passed to eslint for `--stdin-filename` need to be relative to the project root, which is where the .eslintignore must be located.

This change will check for the existence of a `.eslintignore` file, and if one is found, the arguments to `--stdin-filename` will be relative to its directory.

It also adds an `.editorconfig` file to the repo, to make it easier for contributors to use the correct style.