### PR TITLE
Add a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf


### PR DESCRIPTION
Since the `.editorconfig` specifies LF for the EOL add a `.gitattributes` that forces the files to this when being checked out or in.