### PR TITLE
Find all node_modules directories

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -42,9 +42,15 @@ Communication.on('JOB', function(job) {
     configFile = params.configFile
   }
 
-  const modulesPath = find(params.fileDir, 'node_modules')
+  const packageJsonPath = find(params.fileDir, 'package.json')
   const eslintignoreDir = Path.dirname(find(params.fileDir, '.eslintignore'))
   let eslintNewPath = null
+  let modulesPath = null
+
+  if (packageJsonPath !== null) {
+    modulesPath = Path.join(Path.dirname(packageJsonPath), 'node_modules')
+  }
+
   if (modulesPath) {
     process.env.NODE_PATH = modulesPath
   } else process.env.NODE_PATH = ''


### PR DESCRIPTION
Don't stop searching for node_modules directories after first directory is found.

Fixes #294.