### PR TITLE
Check for config in package.json and .eslintrc before disabling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Upcoming
 
 * Allow ignoring the `.eslintignore` file
+* Add `disableWhenNoEslintConfig` config (`true` by default) to only disable the linter if no ESLint config is found in a `package.json`
+or `.eslintrc` file.  This replaces the `disableWhenNoEslintrcFileInPath` config.
 
 ### v5.2.1
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,8 +25,8 @@ export default {
       type: 'boolean',
       default: true
     },
-    disableWhenNoEslintrcFileInPath: {
-      title: 'Disable when no .eslintrc is found',
+    disableWhenNoEslintConfig: {
+      title: 'Disable when no ESLint config is found (in package.json or .eslintrc)',
       type: 'boolean',
       default: true
     },
@@ -145,7 +145,7 @@ export default {
           filePath: filePath,
           contents: text,
           global: atom.config.get('linter-eslint.useGlobalEslint'),
-          canDisable: atom.config.get('linter-eslint.disableWhenNoEslintrcFileInPath'),
+          canDisable: atom.config.get('linter-eslint.disableWhenNoEslintConfig'),
           nodePath: atom.config.get('linter-eslint.globalNodePath'),
           rulesDir: atom.config.get('linter-eslint.eslintRulesDir'),
           configFile: atom.config.get('linter-eslint.eslintrcPath'),

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -32,10 +32,17 @@ function find(startDir, name) {
 Communication.on('JOB', function(job) {
   const params = job.Message
   let configFile = null
+  let configInPackage = false
   global.__LINTER_RESPONSE = []
 
   configFile = find(params.fileDir, '.eslintrc')
-  if (params.canDisable && configFile === null) {
+  if (!configFile) {
+    const packagePath = find(params.fileDir, 'package.json')
+    if (packagePath) {
+      configInPackage = Boolean(require(packagePath).eslintConfig)
+    }
+  }
+  if (params.canDisable && !configFile && !configInPackage) {
     job.Response = []
     return
   } else if (params.configFile) {


### PR DESCRIPTION
This adds a `disableWhenNoEslintConfig` setting.  When `true` (the default), the linter will be disabled only if no config is found in a `package.json` or `.eslintrc` file.

This removes the `disableWhenNoEslintrcFileInPath` setting (which breaks the use of `eslintConfig` in `package.json`).

I couldn't see an easy way to add tests for this.  Let me know if you have any suggestions.  In addition, I'd be happy to rework this if you would prefer to reuse the original setting (or keep it and add the new one).

Fixes #226.