### PR TITLE
Fix find for use with a string arg

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -17,7 +17,7 @@ let prefixPath = null
 
 function find(startDir, names) {
   let localNames;
-  if (typeof name === 'string') {
+  if (typeof names === 'string') {
     localNames = [names]
   } else {
     localNames = names


### PR DESCRIPTION
The change in #319 broke the use of `find` when the second arg is a string.

Fixes #324