### PR TITLE
Communicate worker start depends on user action

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -135,7 +135,7 @@ export default {
           return Promise.resolve([{
             filePath: filePath,
             type: 'Info',
-            text: 'Worker not initialized yet, please try again shortly.',
+            text: 'Worker initialization is delayed. Please try saving or typing to begin linting.',
             range: Helpers.rangeFromLineNumber(textEditor, 0)
           }]);
         }


### PR DESCRIPTION
Attempting to keep users from thinking that they need to wait for the `worker not initialized yet` message to go away.