### PR TITLE
Fix .eslintrc.js

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -44,7 +44,7 @@ Communication.on('JOB', function(job) {
   let configInPackage = false
   global.__LINTER_RESPONSE = []
 
-  configFile = find(params.fileDir, ['eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc'])
+  configFile = find(params.fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc'])
   if (!configFile) {
     const packagePath = find(params.fileDir, 'package.json')
     if (packagePath) {


### PR DESCRIPTION
http://eslint.org/blog/2015/11/eslint-v1.10.0-released/

> Configuration File Formats
> v1.10.0 introduces the ability to use configuration files in different formats. Instead of the regular .eslintrc file, you can use a JavaScript (.eslintrc.js), a YAML file (.eslintrc.yml or .eslintrc.yaml), or a JSON file (.eslintrc.json). We are formally deprecating use of the .eslintrc extensionless configuration file format in favor the format-specific versions. Don't worry, we'll still support .eslintrc files for a long time, but we'd like to encourage everyone to move to the new file formats as you'll get advantages such as syntax highlighting and error detection with many editors. Read more in the documentation.