### PR TITLE
Fix node_module usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 node_modules
 *.log
 .idea
-
-# Keep node_modules test fixtures
-!spec/fixtures/local-eslint/node_modules

--- a/lib/es5-helpers.js
+++ b/lib/es5-helpers.js
@@ -9,7 +9,13 @@ let prefixPath = null
 const atomEslintPath = Path.join(FS.realpathSync(Path.join(__dirname, '..')), 'node_modules', 'eslint')
 
 function findEslintDir(params) {
-  const modulesPath = find(params.fileDir, 'node_modules')
+  let modulesPath = null
+  const packageJsonPath = find(params.fileDir, 'package.json')
+  if (packageJsonPath !== null) {
+    modulesPath = Path.join(Path.dirname(packageJsonPath), 'node_modules')
+  } else {
+    modulesPath = find(params.fileDir, 'node_modules')
+  }
   let eslintNewPath = null
 
   if (params.global) {

--- a/spec/fixtures/local-eslint/.gitignore
+++ b/spec/fixtures/local-eslint/.gitignore
@@ -1,0 +1,2 @@
+# Keep node_modules test fixtures
+!node_modules

--- a/spec/fixtures/local-eslint/lib/node_modules/.gitignore
+++ b/spec/fixtures/local-eslint/lib/node_modules/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Re-implements #313 as we haven't heard from @aruberto in a while.

Uses the node_module at the level of the nearest `package.json` if one exists, otherwise it will search for one starting at the current directory and moving up.

Fixes #294.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/350)
<!-- Reviewable:end -->
