### PR TITLE
Update CircleCI setup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,15 @@
 dependencies:
+  pre:
+    # Force updating wget due to the current containers being too out of date
+    - sudo apt-get update
+    - sudo apt-get install wget
   override:
     - wget -O atom-amd64.deb https://atom.io/download/deb
-    - sudo apt-get update
+    # - sudo apt-get update # Cut out until wget is fixed on the containers
     - sudo dpkg --install atom-amd64.deb || true
     - sudo apt-get -f install -y
     - atom -v
+    - apm -v
     - apm install
 test:
   override:


### PR DESCRIPTION
Force updating `wget` as the current containers for some reason downgraded it and it fails to download Atom now.
Add `apm -v` output.