### PR TITLE
Fix exception for "Fix File" on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming
+
+* Fix file exception on Windows resolution (#353)
+
 ### v5.2.5
 
 * Fix file import resolution (#340)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -84,21 +84,36 @@ Communication.on('JOB', function(job) {
 
 Communication.on('FIX', function(fixJob) {
   const params = fixJob.Message
-  const eslintDir = findEslintDir(params)
+  const modulesPath = find(params.fileDir, 'node_modules')
   const configFile = determineConfigFile(params)
-  const eslintBinPath = Path.normalize(Path.join(eslintDir, 'bin', 'eslint.js'))
+
+  if (modulesPath) {
+    process.env.NODE_PATH = modulesPath
+  } else process.env.NODE_PATH = ''
+  require('module').Module._initPaths()
+
+  // Determine which eslint instance to use
+  const eslintNewPath = findEslintDir(params)
+  if (eslintNewPath !== eslintPath) {
+    eslint = getEslintCli(eslintNewPath)
+    eslintPath = eslintNewPath
+  }
 
   const argv = [
+    process.execPath,
+    eslintPath,
     params.filePath,
     '--fix'
   ]
+
   if (configFile !== null) {
     argv.push('--config', resolveEnv(configFile))
   }
 
   fixJob.Response = new Promise(function(resolve, reject) {
     try {
-      execFileSync(eslintBinPath, argv, {cwd: params.fileDir})
+      process.argv = argv
+      eslint.execute(process.argv)
     } catch (err) {
       reject('Linter-ESLint: Fix Attempt Completed, Linting Errors Remain')
     }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -3,7 +3,6 @@
 process.title = 'linter-eslint helper'
 
 const CP = require('childprocess-promise')
-const execFileSync = require('child_process').execFileSync
 const Path = require('path')
 
 const resolveEnv = require('resolve-env')


### PR DESCRIPTION
This patch fixes the exception raised applying "Fix File" command.

It doesn't follow the disruptive suggestion to assimilate on('FIX' to on('JOB' , because there are too much IF statements.
Maybe we can refactor the listeners later and in another way.

Closes #353