### PR TITLE
Cleanup the codebase

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,128 +4,36 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.find = undefined;
 exports.spawnWorker = spawnWorker;
-exports.findEslintDir = findEslintDir;
-exports.determineConfigFile = determineConfigFile;
-exports.getEslintCli = getEslintCli;
 
 var _child_process = require('child_process');
 
 var _child_process2 = _interopRequireDefault(_child_process);
 
-var _childprocessPromise = require('childprocess-promise');
+var _atom = require('atom');
 
-var _childprocessPromise2 = _interopRequireDefault(_childprocessPromise);
-
-var _fs = require('fs');
-
-var _fs2 = _interopRequireDefault(_fs);
-
-var _path = require('path');
-
-var _path2 = _interopRequireDefault(_path);
-
-var _atomLinter = require('atom-linter');
+var _processCommunication = require('process-communication');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function spawnWorker() {
-  let shouldLive = true;
   const env = Object.create(process.env);
+
   delete env.NODE_PATH;
   delete env.NODE_ENV;
-  const data = { stdout: [], stderr: [] };
+  delete env.OS;
+
   const child = _child_process2.default.fork(__dirname + '/worker.js', [], { env: env, silent: true });
-  const worker = new _childprocessPromise2.default(child);
-  function killer() {
-    shouldLive = false;
-    child.kill();
-  }
+  const worker = (0, _processCommunication.createFromProcess)(child);
+
   child.stdout.on('data', function (chunk) {
-    data.stdout.push(chunk);
+    console.log('[Linter-ESLint] STDOUT', chunk.toString());
   });
   child.stderr.on('data', function (chunk) {
-    data.stderr.push(chunk);
+    console.log('[Linter-ESLint] STDERR', chunk.toString());
   });
-  child.on('exit', function () {
-    if (shouldLive) {
-      console.log('ESLint Worker Info', { stdout: data.stdout.join(''), stderr: data.stderr.join('') });
-      atom.notifications.addWarning('[Linter-ESLint] Worker died unexpectedly', { detail: 'Check your console for more info. A new worker will be spawned instantly.', dismissable: true });
-    }
-    child.emit('exit-linter', shouldLive);
-  });
-  process.on('exit', killer);
-  return { child: child, worker: worker, subscription: { dispose: function () {
-        killer();
-        process.removeListener('exit', killer);
-      } } };
+
+  return { worker: worker, subscription: new _atom.Disposable(function () {
+      worker.kill();
+    }) };
 }
-
-let prefixPath = null;
-const atomEslintPath = _path2.default.normalize(_path2.default.join(__dirname, '..', 'node_modules', 'eslint'));
-
-function findEslintDir(params) {
-  const modulesPath = (0, _atomLinter.find)(params.fileDir, 'node_modules');
-  let eslintNewPath = null;
-
-  if (params.global) {
-    if (params.nodePath === '' && prefixPath === null) {
-      const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-      try {
-        prefixPath = _child_process2.default.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim();
-      } catch (e) {
-        throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly');
-      }
-    }
-    if (process.platform === 'win32') {
-      eslintNewPath = _path2.default.join(params.nodePath || prefixPath, 'node_modules', 'eslint');
-    } else {
-      eslintNewPath = _path2.default.join(params.nodePath || prefixPath, 'lib', 'node_modules', 'eslint');
-    }
-  } else {
-    try {
-      _fs2.default.accessSync(eslintNewPath = _path2.default.join(modulesPath, 'eslint'), _fs2.default.R_OK);
-    } catch (_) {
-      eslintNewPath = atomEslintPath;
-    }
-  }
-
-  return eslintNewPath;
-}
-
-// Check for project config file or eslint config in package.json and determine
-// whether to bail out or use config specified in package options
-function determineConfigFile(params) {
-  // config file
-  const configFile = (0, _atomLinter.find)(params.fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']) || null;
-  if (configFile) {
-    return configFile;
-  }
-  // package.json
-  const packagePath = (0, _atomLinter.find)(params.fileDir, 'package.json');
-  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
-    return packagePath;
-  }
-  // Couldn't find a config
-  if (params.canDisable) {
-    return null;
-  }
-  // If all else fails, use the configFile specified in the linter-eslint options
-  if (params.configFile) {
-    return params.configFile;
-  }
-}
-
-function getEslintCli(path) {
-  try {
-    const eslint = require(_path2.default.join(path, 'lib', 'cli.js'));
-    return eslint;
-  } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
-      throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly');
-    } else throw e;
-  }
-}
-
-exports.find = _atomLinter.find;

--- a/lib/main.js
+++ b/lib/main.js
@@ -61,6 +61,12 @@ module.exports = {
       title: 'Disable using .eslintignore files',
       type: 'boolean',
       default: false
+    },
+    disableFSCache: {
+      title: 'Disable FileSystem Cache',
+      description: 'Paths of node_modules, .eslintignore and others are cached',
+      type: 'boolean',
+      default: false
     }
   },
   activate: function () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,10 +1,6 @@
 'use strict';
 'use babel';
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
 var _path = require('path');
 
 var _path2 = _interopRequireDefault(_path);
@@ -19,7 +15,7 @@ var _escapeHtml2 = _interopRequireDefault(_escapeHtml);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = {
+module.exports = {
   config: {
     lintHtmlFiles: {
       title: 'Lint HTML Files',
@@ -99,18 +95,10 @@ exports.default = {
           return;
         }
 
-        if (_this.worker === null) {
-          // Abort if worker is not yet ready
-          atom.notifications.addError('Linter-ESLint: Not ready, please try again');
-          return;
-        }
-
-        _this.worker.request('FIX', {
-          fileDir: fileDir,
-          filePath: filePath,
-          global: atom.config.get('linter-eslint.useGlobalEslint'),
-          nodePath: atom.config.get('linter-eslint.globalNodePath'),
-          configFile: atom.config.get('linter-eslint.eslintrcPath')
+        _this.worker.request('job', {
+          type: 'lint',
+          config: atom.config.get('linter-eslint'),
+          filePath: filePath
         }).then(function (response) {
           atom.notifications.addSuccess(response);
         }).catch(function (response) {
@@ -119,30 +107,22 @@ exports.default = {
       }
     }));
 
-    // Reason: I (steelbrain) have observed that if we spawn a
-    // process while atom is starting up, it can increase startup
-    // time by several seconds, But if we do this after 5 seconds,
-    // we barely feel a thing.
     const initializeWorker = function () {
-      if (_this.active) {
-        var _spawnWorker = (0, _helpers.spawnWorker)();
+      var _spawnWorker = (0, _helpers.spawnWorker)();
 
-        const child = _spawnWorker.child;
-        const worker = _spawnWorker.worker;
-        const subscription = _spawnWorker.subscription;
+      const worker = _spawnWorker.worker;
+      const subscription = _spawnWorker.subscription;
 
-        _this.worker = worker;
-        _this.subscriptions.add(subscription);
-        child.on('exit-linter', function (shouldLive) {
-          _this.worker = null;
-          // Respawn if it crashed. See atom/electron#3446
-          if (shouldLive) {
-            initializeWorker();
-          }
-        });
-      }
+      _this.worker = worker;
+      _this.subscriptions.add(subscription);
+      worker.onDidExit(function () {
+        if (_this.active) {
+          atom.notifications.addWarning('[Linter-ESLint] Worker died unexpectedly', { detail: 'Check your console for more info. A new worker will be spawned instantly.', dismissable: true });
+          setTimeout(initializeWorker, 1000);
+        }
+      });
     };
-    setTimeout(initializeWorker, 5 * 1000);
+    initializeWorker();
   },
   deactivate: function () {
     this.active = false;
@@ -163,32 +143,14 @@ exports.default = {
           return Promise.resolve([]);
         }
         const filePath = textEditor.getPath();
-        const fileDir = _path2.default.dirname(filePath);
         const showRule = atom.config.get('linter-eslint.showRuleIdInMessage');
 
-        if (_this2.worker === null) {
-          return Promise.resolve([{
-            filePath: filePath,
-            type: 'Info',
-            text: 'Worker initialization is delayed. Please try saving or typing to begin linting.',
-            range: Helpers.rangeFromLineNumber(textEditor, 0)
-          }]);
-        }
-
-        return _this2.worker.request('JOB', {
-          fileDir: fileDir,
-          filePath: filePath,
+        return _this2.worker.request('job', {
           contents: text,
-          global: atom.config.get('linter-eslint.useGlobalEslint'),
-          canDisable: atom.config.get('linter-eslint.disableWhenNoEslintConfig'),
-          nodePath: atom.config.get('linter-eslint.globalNodePath'),
-          rulesDir: atom.config.get('linter-eslint.eslintRulesDir'),
-          configFile: atom.config.get('linter-eslint.eslintrcPath'),
-          disableIgnores: atom.config.get('linter-eslint.disableEslintIgnore')
+          type: 'lint',
+          config: atom.config.get('linter-eslint'),
+          filePath: filePath
         }).then(function (response) {
-          if (response.length === 1 && response[0].message === 'File ignored because of your .eslintignore file. Use --no-ignore to override.') {
-            return [];
-          }
           return response.map(function (_ref) {
             let message = _ref.message;
             let line = _ref.line;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,5 +1,5 @@
 'use strict'
 // This file is used by eslint to hand the errors over to the worker
 module.exports = function(results) {
-  global.__LINTER_RESPONSE = results[0].messages
+  global.__LINTER_ESLINT_RESPONSE = results[0].messages
 }

--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -1,0 +1,142 @@
+'use strict';
+'use babel';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getESLintInstance = getESLintInstance;
+exports.getESLintFromDirectory = getESLintFromDirectory;
+exports.refreshModulesPath = refreshModulesPath;
+exports.getNodePrefixPath = getNodePrefixPath;
+exports.getConfigPath = getConfigPath;
+exports.getRelativePath = getRelativePath;
+exports.getArgv = getArgv;
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+var _child_process = require('child_process');
+
+var _child_process2 = _interopRequireDefault(_child_process);
+
+var _resolveEnv = require('resolve-env');
+
+var _resolveEnv2 = _interopRequireDefault(_resolveEnv);
+
+var _atomLinter = require('atom-linter');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const Cache = {
+  ESLINT_LOCAL_PATH: _path2.default.normalize(__dirname, '..', 'node_modules', 'eslint'),
+  NODE_PREFIX_PATH: null,
+  LAST_MODULES_PATH: null
+};
+
+function getESLintInstance(fileDir, config) {
+  const modulesDir = (0, _atomLinter.findCached)(fileDir, 'node_modules');
+  refreshModulesPath(modulesDir);
+  return getESLintFromDirectory(modulesDir, config);
+}
+
+function getESLintFromDirectory(modulesDir, config) {
+  let ESLintDirectory = null;
+
+  if (config.useGlobalEslint) {
+    const prefixPath = config.globalNodePath || getNodePrefixPath();
+    if (process.platform === 'win32') {
+      ESLintDirectory = _path2.default.join(prefixPath, 'node_modules', 'eslint');
+    } else {
+      ESLintDirectory = _path2.default.join(prefixPath, 'lib', 'node_modules', 'eslint');
+    }
+  } else {
+    if (modulesDir === null) {
+      throw new Error('Cannot find module `eslint`');
+    }
+    ESLintDirectory = _path2.default.join(modulesDir, 'eslint');
+  }
+  try {
+    return require(_path2.default.join(ESLintDirectory, 'lib', 'cli.js'));
+  } catch (e) {
+    if (config.useGlobalEslint && e.code === 'MODULE_NOT_FOUND') {
+      throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly');
+    }
+    return require(Cache.ESLINT_LOCAL_PATH);
+  }
+}
+
+function refreshModulesPath(modulesDir) {
+  if (Cache.LAST_MODULES_PATH !== modulesDir) {
+    Cache.LAST_MODULES_PATH = modulesDir;
+    process.env.NODE_PATH = modulesDir || '';
+    require('module').Module._initPaths();
+  }
+}
+
+function getNodePrefixPath() {
+  if (Cache.NODE_PREFIX_PATH === null) {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    try {
+      Cache.NODE_PREFIX_PATH = _child_process2.default.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim();
+    } catch (e) {
+      throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly');
+    }
+  }
+  return Cache.NODE_PREFIX_PATH;
+}
+
+function getConfigPath(fileDir) {
+  const configFile = (0, _atomLinter.findCached)(fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']);
+  if (configFile) {
+    return configFile;
+  }
+
+  const packagePath = (0, _atomLinter.findCached)(fileDir, 'package.json');
+  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
+    return packagePath;
+  }
+  return null;
+}
+
+function getRelativePath(fileDir, filePath, config) {
+  const ignoreFile = config.disableEslintIgnore ? null : (0, _atomLinter.findCached)(fileDir);
+
+  if (ignoreFile) {
+    const ignoreDir = _path2.default.dirname(ignoreFile);
+    process.chdir(ignoreDir);
+    return _path2.default.relative(ignoreDir, filePath);
+  } else {
+    process.chdir(fileDir);
+    return _path2.default.basename(filePath);
+  }
+}
+
+function getArgv(config, filePath, fileDir, configPath) {
+  if (configPath === null && config.disableWhenNoEslintConfig) {
+    return [];
+  } else {
+    configPath = config.eslintrcPath || null;
+  }
+  const argv = [process.execPath, 'a-b-c', // dummy value for eslint cwd
+  '--stdin', '--format', _path2.default.join(__dirname, 'reporter.js')];
+
+  if (config.eslintRulesDir) {
+    let rulesDir = (0, _resolveEnv2.default)(config.eslintRulesDir);
+    if (!_path2.default.isAbsolute(rulesDir)) {
+      rulesDir = (0, _atomLinter.findCached)(fileDir, rulesDir);
+    }
+    argv.push('--rulesdir', rulesDir);
+  }
+  if (configPath) {
+    argv.push('--config', (0, _resolveEnv2.default)(configPath));
+  }
+  if (config.disableEslintIgnore) {
+    argv.push('--no-ignore');
+  }
+  argv.push('--stdin-filename', filePath);
+}

--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -33,7 +33,7 @@ var _atomLinter = require('atom-linter');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const Cache = {
-  ESLINT_LOCAL_PATH: _path2.default.normalize(__dirname, '..', 'node_modules', 'eslint'),
+  ESLINT_LOCAL_PATH: _path2.default.normalize(_path2.default.join(__dirname, '..', 'node_modules', 'eslint')),
   NODE_PREFIX_PATH: null,
   LAST_MODULES_PATH: null
 };
@@ -55,10 +55,7 @@ function getESLintFromDirectory(modulesDir, config) {
       ESLintDirectory = _path2.default.join(prefixPath, 'lib', 'node_modules', 'eslint');
     }
   } else {
-    if (modulesDir === null) {
-      throw new Error('Cannot find module `eslint`');
-    }
-    ESLintDirectory = _path2.default.join(modulesDir, 'eslint');
+    ESLintDirectory = _path2.default.join(modulesDir || '', 'eslint');
   }
   try {
     return require(_path2.default.join(ESLintDirectory, 'lib', 'cli.js'));
@@ -66,7 +63,7 @@ function getESLintFromDirectory(modulesDir, config) {
     if (config.useGlobalEslint && e.code === 'MODULE_NOT_FOUND') {
       throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly');
     }
-    return require(Cache.ESLINT_LOCAL_PATH);
+    return require(_path2.default.join(Cache.ESLINT_LOCAL_PATH, 'lib', 'cli.js'));
   }
 }
 
@@ -117,9 +114,7 @@ function getRelativePath(fileDir, filePath, config) {
 }
 
 function getArgv(config, filePath, fileDir, configPath) {
-  if (configPath === null && config.disableWhenNoEslintConfig) {
-    return [];
-  } else {
+  if (configPath === null) {
     configPath = config.eslintrcPath || null;
   }
   const argv = [process.execPath, 'a-b-c', // dummy value for eslint cwd

--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -104,7 +104,7 @@ function getConfigPath(fileDir) {
 }
 
 function getRelativePath(fileDir, filePath, config) {
-  const ignoreFile = config.disableEslintIgnore ? null : (0, _atomLinter.findCached)(fileDir);
+  const ignoreFile = config.disableEslintIgnore ? null : (0, _atomLinter.findCached)(fileDir, '.eslintignore');
 
   if (ignoreFile) {
     const ignoreDir = _path2.default.dirname(ignoreFile);
@@ -139,4 +139,6 @@ function getArgv(config, filePath, fileDir, configPath) {
     argv.push('--no-ignore');
   }
   argv.push('--stdin-filename', filePath);
+
+  return argv;
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,122 +1,60 @@
-'use strict'
+'use strict';
+'use babel';
 // Note: 'use babel' doesn't work in forked processes
-process.title = 'linter-eslint helper'
 
-const CP = require('childprocess-promise')
-const Path = require('path')
+var _path = require('path');
 
-const resolveEnv = require('resolve-env')
-const Helpers = require('./helpers')
+var _path2 = _interopRequireDefault(_path);
 
-const findEslintDir = Helpers.findEslintDir
-const find = Helpers.find
-const determineConfigFile = Helpers.determineConfigFile
-const getEslintCli = Helpers.getEslintCli
-const Communication = new CP()
+var _workerHelpers = require('./worker-helpers');
 
-// closed-over module-scope variables
-let eslintPath = null
-let eslint = null
+var Helpers = _interopRequireWildcard(_workerHelpers);
 
-Communication.on('JOB', function(job) {
-  const params = job.Message
-  const modulesPath = find(params.fileDir, 'node_modules')
-  const eslintignoreDir = Path.dirname(find(params.fileDir, '.eslintignore'))
-  // Check for config file
-  const configFile = determineConfigFile(params)
-  global.__LINTER_RESPONSE = []
+var _processCommunication = require('process-communication');
 
-  // Determine whether to bail out
-  if (params.canDisable && configFile === null) {
-    job.Response = []
-    return
+var _atomLinter = require('atom-linter');
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+process.title = 'linter-eslint helper';
+
+(0, _processCommunication.create)().onRequest('job', function (_ref, job) {
+  let contents = _ref.contents;
+  let type = _ref.type;
+  let config = _ref.config;
+  let filePath = _ref.filePath;
+
+  global.__LINTER_ESLINT_RESPONSE = [];
+
+  const fileDir = _path2.default.dirname(filePath);
+  const eslint = Helpers.getESLintInstance(fileDir, config);
+  const configPath = Helpers.getConfigPath(fileDir);
+  const relativeFilePath = Helpers.getRelativePath(fileDir, filePath, config);
+
+  const argv = Helpers.getArgv(config, relativeFilePath, fileDir, configPath);
+
+  if (type === 'lint') {
+    job.response = lintJob(argv, contents, eslint);
+  } else if (type === 'fix') {
+    job.response = fixJob(argv, eslint);
   }
+});
 
-  if (modulesPath) {
-    process.env.NODE_PATH = modulesPath
-  } else process.env.NODE_PATH = ''
-  require('module').Module._initPaths()
-
-  // Determine which eslint instance to use
-  const eslintNewPath = findEslintDir(params)
-  if (eslintNewPath !== eslintPath) {
-    eslint = getEslintCli(eslintNewPath)
-    eslintPath = eslintNewPath
+function lintJob(argv, contents, eslint) {
+  eslint.execute(argv, contents);
+  return global.__LINTER_ESLINT_RESPONSE;
+}
+function fixJob(argv, eslint) {
+  argv.push('--fix');
+  try {
+    process.argv = argv;
+    eslint.execute(argv);
+    return 'Linter-ESLint: Fix Complete';
+  } catch (err) {
+    throw new Error('Linter-ESLint: Fix Attempt Completed, Linting Errors Remain');
   }
+}
 
-  job.Response = new Promise(function(resolve) {
-    let filePath
-    if (eslintignoreDir) {
-      filePath = Path.relative(eslintignoreDir, params.filePath)
-      process.chdir(eslintignoreDir)
-    } else {
-      filePath = Path.basename(params.filePath)
-      process.chdir(params.fileDir)
-    }
-    const argv = [
-      process.execPath,
-      eslintPath,
-      '--stdin',
-      '--format',
-      Path.join(__dirname, 'reporter.js')
-    ]
-    if (params.rulesDir) {
-      let rulesDir = resolveEnv(params.rulesDir)
-      if (!Path.isAbsolute(rulesDir)) {
-        rulesDir = find(params.fileDir, rulesDir)
-      }
-      argv.push('--rulesdir', rulesDir)
-    }
-    if (typeof configFile === 'string') {
-      argv.push('--config', resolveEnv(configFile))
-    }
-    if (params.disableIgnores) {
-      argv.push('--no-ignore')
-    }
-    argv.push('--stdin-filename', filePath)
-    process.argv = argv
-    eslint.execute(process.argv, params.contents)
-    resolve(global.__LINTER_RESPONSE)
-  })
-})
-
-Communication.on('FIX', function(fixJob) {
-  const params = fixJob.Message
-  const modulesPath = find(params.fileDir, 'node_modules')
-  const configFile = determineConfigFile(params)
-
-  if (modulesPath) {
-    process.env.NODE_PATH = modulesPath
-  } else process.env.NODE_PATH = ''
-  require('module').Module._initPaths()
-
-  // Determine which eslint instance to use
-  const eslintNewPath = findEslintDir(params)
-  if (eslintNewPath !== eslintPath) {
-    eslint = getEslintCli(eslintNewPath)
-    eslintPath = eslintNewPath
-  }
-
-  const argv = [
-    process.execPath,
-    eslintPath,
-    params.filePath,
-    '--fix'
-  ]
-
-  if (typeof configFile === 'string') {
-    argv.push('--config', resolveEnv(configFile))
-  }
-
-  fixJob.Response = new Promise(function(resolve, reject) {
-    try {
-      process.argv = argv
-      eslint.execute(process.argv)
-    } catch (err) {
-      reject('Linter-ESLint: Fix Attempt Completed, Linting Errors Remain')
-    }
-    resolve('Linter-ESLint: Fix Complete')
-  })
-})
-
-process.exit = function() { /* Stop eslint from closing the daemon */ }
+process.exit = function () {/* Stop eslint from closing the daemon */};

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -28,6 +28,10 @@ process.title = 'linter-eslint helper';
 
   global.__LINTER_ESLINT_RESPONSE = [];
 
+  if (config.disableFSCache) {
+    _atomLinter.FindCache.clear();
+  }
+
   const fileDir = _path2.default.dirname(filePath);
   const eslint = Helpers.getESLintInstance(fileDir, config);
   const configPath = Helpers.getConfigPath(fileDir);
@@ -36,13 +40,16 @@ process.title = 'linter-eslint helper';
   const argv = Helpers.getArgv(config, relativeFilePath, fileDir, configPath);
 
   if (type === 'lint') {
-    job.response = lintJob(argv, contents, eslint);
+    job.response = lintJob(argv, contents, eslint, configPath, config);
   } else if (type === 'fix') {
     job.response = fixJob(argv, eslint);
   }
 });
 
-function lintJob(argv, contents, eslint) {
+function lintJob(argv, contents, eslint, configPath, config) {
+  if (configPath === null && config.disableWhenNoEslintConfig) {
+    return [];
+  }
   eslint.execute(argv, contents);
   return global.__LINTER_ESLINT_RESPONSE;
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "atom-linter": "^4.0.1",
+    "atom-linter": "^4.1.1",
     "atom-package-deps": "^3.0.5",
     "escape-html": "^1.0.3",
     "eslint": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "atom-linter": "^4.0.1",
     "atom-package-deps": "^3.0.5",
-    "childprocess-promise": "^3.0.0",
     "escape-html": "^1.0.3",
     "eslint": "^1.10.1",
+    "process-communication": "^1.1.0",
     "resolve-env": "^1.0.0"
   },
   "devDependencies": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,11 +1,9 @@
 'use babel'
 
-import Path from 'path'
-import FS from 'fs'
 import ChildProcess from 'child_process'
 import {Disposable} from 'atom'
 import {createFromProcess} from 'process-communication'
-import {find} from 'atom-linter'
+
 
 export function spawnWorker() {
   const env = Object.create(process.env)
@@ -27,103 +25,4 @@ export function spawnWorker() {
   return {worker, subscription: new Disposable(function() {
     worker.kill()
   })}
-}
-
-export function getModulesDirectory(fileDir) {
-  return find(fileDir, 'node_modules')
-}
-
-export function getIgnoresFile(fileDir) {
-  return Path.dirname(find(fileDir, '.eslintignore'))
-}
-
-export function getEslintFromDirectory(path) {
-  try {
-    return require(Path.join(path, 'lib', 'cli.js'))
-  } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
-      throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly')
-    } else throw e
-  }
-}
-
-let nodePrefixPath = null
-
-export function getNodePrefixPath() {
-  if (nodePrefixPath === null) {
-    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-    try {
-      nodePrefixPath = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
-    } catch (e) {
-      throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly')
-    }
-  }
-  return nodePrefixPath
-}
-
-let bundledEslintDirectory = null
-
-export function getBundledEslintDirectory() {
-  if (bundledEslintDirectory === null) {
-    bundledEslintDirectory = Path.normalize(Path.join(__dirname, '..', 'node_modules', 'eslint'))
-  }
-  return bundledEslintDirectory
-}
-
-export function getEslintDirectory(params, modulesPath = null) {
-  if (params.global) {
-    const prefixPath = getNodePrefixPath()
-    if (process.platform === 'win32') {
-      return Path.join(params.nodePath || prefixPath, 'node_modules', 'eslint')
-    }
-    return Path.join(params.nodePath || prefixPath, 'lib', 'node_modules', 'eslint')
-  }
-  const eslintPath = Path.join(modulesPath || getModulesDirectory(params.fileDir), 'eslint')
-  try {
-    FS.accessSync(eslintPath, FS.R_OK)
-    return eslintPath
-  } catch (_) {
-    return getBundledEslintDirectory()
-  }
-}
-
-export function getEslintConfig(params) {
-  const configFile = find(params.fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']) || null
-  if (configFile) {
-    return configFile
-  }
-
-  const packagePath = find(params.fileDir, 'package.json')
-  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
-    return packagePath
-  }
-
-  if (params.canDisable) {
-    return null
-  }
-
-  if (params.configFile) {
-    return params.configFile
-  }
-}
-
-let eslint
-let lastEslintDirectory
-let lastModulesPath
-
-export function getEslint(params) {
-  const modulesPath = getModulesDirectory(params.fileDir)
-  const eslintDirectory = getEslintDirectory(params, modulesPath)
-  if (eslintDirectory !== lastEslintDirectory) {
-    lastEslintDirectory = eslintDirectory
-    eslint = getEslintFromDirectory(eslintDirectory)
-  }
-  if (lastModulesPath !== modulesPath) {
-    lastModulesPath = modulesPath
-    if (modulesPath) {
-      process.env.NODE_PATH = modulesPath
-    } else process.env.NODE_PATH = ''
-    require('module').Module._initPaths()
-  }
-  return {eslint, eslintDirectory}
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,9 @@
 'use babel'
 
+import Path from 'path'
+import FS from 'fs'
 import ChildProcess from 'child_process'
 import CP from 'childprocess-promise'
-import FS from 'fs'
-import Path from 'path'
 import {find} from 'atom-linter'
 
 export function spawnWorker() {
@@ -38,65 +38,17 @@ export function spawnWorker() {
   }}}
 }
 
-let prefixPath = null
-const atomEslintPath = Path.normalize(Path.join(__dirname, '..', 'node_modules', 'eslint'))
-
-export function findEslintDir(params) {
-  const modulesPath = find(params.fileDir, 'node_modules')
-  let eslintNewPath = null
-
-  if (params.global) {
-    if (params.nodePath === '' && prefixPath === null) {
-      const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-      try {
-        prefixPath = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
-      } catch (e) {
-        throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly')
-      }
-    }
-    if (process.platform === 'win32') {
-      eslintNewPath = Path.join(params.nodePath || prefixPath, 'node_modules', 'eslint')
-    } else {
-      eslintNewPath = Path.join(params.nodePath || prefixPath, 'lib', 'node_modules', 'eslint')
-    }
-  } else {
-    try {
-      FS.accessSync(eslintNewPath = Path.join(modulesPath, 'eslint'), FS.R_OK)
-    } catch (_) {
-      eslintNewPath = atomEslintPath
-    }
-  }
-
-  return eslintNewPath
+export function getModulesDirectory(fileDir) {
+  return find(fileDir, 'node_modules')
 }
 
-// Check for project config file or eslint config in package.json and determine
-// whether to bail out or use config specified in package options
-export function determineConfigFile(params) {
-  // config file
-  const configFile = find(params.fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']) || null
-  if (configFile) {
-    return configFile
-  }
-  // package.json
-  const packagePath = find(params.fileDir, 'package.json')
-  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
-    return packagePath
-  }
-  // Couldn't find a config
-  if (params.canDisable) {
-    return null
-  }
-  // If all else fails, use the configFile specified in the linter-eslint options
-  if (params.configFile) {
-    return params.configFile
-  }
+export function getIgnoresFile(fileDir) {
+  return Path.dirname(find(fileDir, '.eslintignore'))
 }
 
-export function getEslintCli(path) {
+export function getEslintFromDirectory(path) {
   try {
-    const eslint = require(Path.join(path, 'lib', 'cli.js'))
-    return eslint
+    return require(Path.join(path, 'lib', 'cli.js'))
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
       throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly')
@@ -104,4 +56,83 @@ export function getEslintCli(path) {
   }
 }
 
-export {find}
+let nodePrefixPath = null
+
+export function getNodePrefixPath() {
+  if (nodePrefixPath === null) {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    try {
+      nodePrefixPath = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
+    } catch (e) {
+      throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly')
+    }
+  }
+  return nodePrefixPath
+}
+
+let bundledEslintDirectory = null
+
+export function getBundledEslintDirectory() {
+  if (bundledEslintDirectory === null) {
+    bundledEslintDirectory = Path.normalize(Path.join(__dirname, '..', 'node_modules', 'eslint'))
+  }
+  return bundledEslintDirectory
+}
+
+export function getEslintDirectory(params, modulesPath = null) {
+  if (params.global) {
+    const prefixPath = getNodePrefixPath()
+    if (process.platform === 'win32') {
+      return Path.join(params.nodePath || prefixPath, 'node_modules', 'eslint')
+    }
+    return Path.join(params.nodePath || prefixPath, 'lib', 'node_modules', 'eslint')
+  }
+  const eslintPath = Path.join(modulesPath || getModulesDirectory(params.fileDir), 'eslint')
+  try {
+    FS.accessSync(eslintPath, FS.R_OK)
+    return eslintPath
+  } catch (_) {
+    return getBundledEslintDirectory()
+  }
+}
+
+export function getEslintConfig(params) {
+  const configFile = find(params.fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']) || null
+  if (configFile) {
+    return configFile
+  }
+
+  const packagePath = find(params.fileDir, 'package.json')
+  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
+    return packagePath
+  }
+
+  if (params.canDisable) {
+    return null
+  }
+
+  if (params.configFile) {
+    return params.configFile
+  }
+}
+
+let eslint
+let lastEslintDirectory
+let lastModulesPath
+
+export function getEslint(params) {
+  const modulesPath = getModulesDirectory(params.fileDir)
+  const eslintDirectory = getEslintDirectory(params, modulesPath)
+  if (eslintDirectory !== lastEslintDirectory) {
+    lastEslintDirectory = eslintDirectory
+    eslint = getEslintFromDirectory(eslintDirectory)
+  }
+  if (lastModulesPath !== modulesPath) {
+    lastModulesPath = modulesPath
+    if (modulesPath) {
+      process.env.NODE_PATH = modulesPath
+    } else process.env.NODE_PATH = ''
+    require('module').Module._initPaths()
+  }
+  return {eslint, eslintDirectory}
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,7 +4,6 @@ import ChildProcess from 'child_process'
 import {Disposable} from 'atom'
 import {createFromProcess} from 'process-communication'
 
-
 export function spawnWorker() {
   const env = Object.create(process.env)
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,10 +18,10 @@ export function spawnWorker() {
   const worker = createFromProcess(child)
 
   child.stdout.on('data', function (chunk) {
-    console.log('[Linter-ESLint] STDOUT', chunk)
+    console.log('[Linter-ESLint] STDOUT', chunk.toString())
   })
   child.stderr.on('data', function (chunk) {
-    console.log('[Linter-ESLint] STDERR', chunk)
+    console.log('[Linter-ESLint] STDERR', chunk.toString())
   })
 
   return {worker, subscription: new Disposable(function() {

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import {CompositeDisposable} from 'atom'
 import {spawnWorker} from './helpers'
 import escapeHTML from 'escape-html'
 
-export default {
+module.exports = {
   config: {
     lintHtmlFiles: {
       title: 'Lint HTML Files',
@@ -105,13 +105,15 @@ export default {
 
     const initializeWorker = () => {
       if (this.active) {
-        if (this.worker !== null) {
-          atom.notifications.addWarning('[Linter-ESLint] Worker died unexpectedly', {detail: 'Check your console for more info. A new worker will be spawned instantly.', dismissable: true})
-        }
         const {worker, subscription} = spawnWorker()
         this.worker = worker
         this.subscriptions.add(subscription)
-        worker.onDidExit(initializeWorker)
+        worker.onDidExit(() => {
+          if (this.active) {
+            atom.notifications.addWarning('[Linter-ESLint] Worker died unexpectedly', {detail: 'Check your console for more info. A new worker will be spawned instantly.', dismissable: true})
+            setTimeout(initializeWorker, 1000)
+          }
+        })
       }
     }
     initializeWorker()

--- a/src/main.js
+++ b/src/main.js
@@ -51,6 +51,12 @@ module.exports = {
       title: 'Disable using .eslintignore files',
       type: 'boolean',
       default: false
+    },
+    disableFSCache: {
+      title: 'Disable FileSystem Cache',
+      description: 'Paths of node_modules, .eslintignore and others are cached',
+      type: 'boolean',
+      default: false
     }
   },
   activate: function() {

--- a/src/main.js
+++ b/src/main.js
@@ -83,12 +83,6 @@ module.exports = {
           return
         }
 
-        if (this.worker === null) {
-          // Abort if worker is not yet ready
-          atom.notifications.addError('Linter-ESLint: Not ready, please try again')
-          return
-        }
-
         this.worker.request('FIX', {
           fileDir: fileDir,
           filePath: filePath,
@@ -137,15 +131,6 @@ module.exports = {
         const filePath = textEditor.getPath()
         const fileDir = Path.dirname(filePath)
         const showRule = atom.config.get('linter-eslint.showRuleIdInMessage')
-
-        if (this.worker === null) {
-          return Promise.resolve([{
-            filePath: filePath,
-            type: 'Info',
-            text: 'Worker initialization is delayed. Please try saving or typing to begin linting.',
-            range: Helpers.rangeFromLineNumber(textEditor, 0)
-          }])
-        }
 
         return this.worker.request('JOB', {
           fileDir: fileDir,

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,5 +1,5 @@
 'use strict'
 // This file is used by eslint to hand the errors over to the worker
 module.exports = function(results) {
-  global.__LINTER_RESPONSE = results[0].messages
+  global.__LINTER_ESLINT_RESPONSE = results[0].messages
 }

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -1,0 +1,104 @@
+'use babel'
+
+import Path from 'path'
+import FS from 'fs'
+import {find} from 'atom-linter'
+
+export function getEslint(params) {
+  const modulesPath = getModulesDirectory(params.fileDir)
+  const eslintDirectory = getEslintDirectory(params, modulesPath)
+  if (eslintDirectory !== lastEslintDirectory) {
+    lastEslintDirectory = eslintDirectory
+    eslint = getEslintFromDirectory(eslintDirectory)
+  }
+  if (lastModulesPath !== modulesPath) {
+    lastModulesPath = modulesPath
+    if (modulesPath) {
+      process.env.NODE_PATH = modulesPath
+    } else process.env.NODE_PATH = ''
+    require('module').Module._initPaths()
+  }
+  return {eslint, eslintDirectory}
+}
+
+export function getESLint(filePath, config) {
+  const fileDir = Path.dirname(filePath)
+}
+
+export function getModulesDirectory(fileDir) {
+  return find(fileDir, 'node_modules')
+}
+
+export function getIgnoresFile(fileDir) {
+  return Path.dirname(find(fileDir, '.eslintignore'))
+}
+
+export function getEslintFromDirectory(path) {
+  try {
+    return require(Path.join(path, 'lib', 'cli.js'))
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly')
+    } else throw e
+  }
+}
+
+let nodePrefixPath = null
+
+export function getNodePrefixPath() {
+  if (nodePrefixPath === null) {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    try {
+      nodePrefixPath = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
+    } catch (e) {
+      throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly')
+    }
+  }
+  return nodePrefixPath
+}
+
+let bundledEslintDirectory = null
+
+export function getBundledEslintDirectory() {
+  if (bundledEslintDirectory === null) {
+    bundledEslintDirectory = Path.normalize(Path.join(__dirname, '..', 'node_modules', 'eslint'))
+  }
+  return bundledEslintDirectory
+}
+
+export function getEslintDirectory(params, modulesPath = null) {
+  if (params.global) {
+    const prefixPath = getNodePrefixPath()
+    if (process.platform === 'win32') {
+      return Path.join(params.nodePath || prefixPath, 'node_modules', 'eslint')
+    }
+    return Path.join(params.nodePath || prefixPath, 'lib', 'node_modules', 'eslint')
+  }
+  const eslintPath = Path.join(modulesPath || getModulesDirectory(params.fileDir), 'eslint')
+  try {
+    FS.accessSync(eslintPath, FS.R_OK)
+    return eslintPath
+  } catch (_) {
+    return getBundledEslintDirectory()
+  }
+}
+
+export function getEslintConfig(params) {
+  const configFile = find(params.fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']) || null
+  if (configFile) {
+    return configFile
+  }
+
+  const packagePath = find(params.fileDir, 'package.json')
+  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
+    return packagePath
+  }
+
+  if (params.canDisable) {
+    return null
+  }
+
+  if (params.configFile) {
+    return params.configFile
+  }
+}

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -78,7 +78,7 @@ export function getConfigPath(fileDir) {
 }
 
 export function getRelativePath(fileDir, filePath, config) {
-  const ignoreFile = config.disableEslintIgnore ? null : findCached(fileDir)
+  const ignoreFile = config.disableEslintIgnore ? null : findCached(fileDir, '.eslintignore')
 
   if (ignoreFile) {
     const ignoreDir = Path.dirname(ignoreFile)
@@ -118,4 +118,6 @@ export function getArgv(config, filePath, fileDir, configPath) {
     argv.push('--no-ignore')
   }
   argv.push('--stdin-filename', filePath)
+
+  return argv
 }

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -2,103 +2,78 @@
 
 import Path from 'path'
 import FS from 'fs'
-import {find} from 'atom-linter'
+import ChildProcess from 'child_process'
+import {findCached} from 'atom-linter'
 
-export function getEslint(params) {
-  const modulesPath = getModulesDirectory(params.fileDir)
-  const eslintDirectory = getEslintDirectory(params, modulesPath)
-  if (eslintDirectory !== lastEslintDirectory) {
-    lastEslintDirectory = eslintDirectory
-    eslint = getEslintFromDirectory(eslintDirectory)
+const Cache = {
+  ESLINT_LOCAL_PATH: Path.normalize(__dirname, '..', 'node_modules', 'eslint'),
+  NODE_PREFIX_PATH: null,
+  LAST_MODULES_PATH: null
+}
+
+export function getESLintInstance(filePath, config) {
+  const fileDir = Path.dirname(filePath)
+  const modulesDir = findCached(fileDir, 'node_modules')
+
+  refreshModulesPath(modulesDir)
+  return getESLintFromDirectory(modulesDir, config)
+}
+
+export function getESLintFromDirectory(modulesDir, config) {
+  let ESLintDirectory = null
+
+  if (config.useGlobalEslint) {
+    const prefixPath = config.globalNodePath || getNodePrefixPath()
+    if (process.platform === 'win32') {
+      ESLintDirectory = Path.join(prefixPath, 'node_modules', 'eslint')
+    } else {
+      ESLintDirectory = Path.join(prefixPath, 'lib', 'node_modules', 'eslint')
+    }
+  } else {
+    if (modulesDir === null) {
+      throw new Error('Cannot find module `eslint`')
+    }
+    ESLintDirectory = Path.join(modulesDir, 'eslint')
   }
-  if (lastModulesPath !== modulesPath) {
-    lastModulesPath = modulesPath
-    if (modulesPath) {
-      process.env.NODE_PATH = modulesPath
-    } else process.env.NODE_PATH = ''
+  try {
+    return require(Path.join(ESLintDirectory, 'lib', 'cli.js'))
+  } catch (e) {
+    if (config.useGlobalEslint && e.code === 'MODULE_NOT_FOUND') {
+      throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly')
+    }
+    return require(Cache.ESLINT_LOCAL_PATH)
+  }
+}
+
+export function refreshModulesPath(modulesDir) {
+  if (Cache.LAST_MODULES_PATH !== modulesDir) {
+    Cache.LAST_MODULES_PATH = modulesDir
+    process.env.NODE_PATH = modulesDir || ''
     require('module').Module._initPaths()
   }
-  return {eslint, eslintDirectory}
 }
-
-export function getESLint(filePath, config) {
-  const fileDir = Path.dirname(filePath)
-}
-
-export function getModulesDirectory(fileDir) {
-  return find(fileDir, 'node_modules')
-}
-
-export function getIgnoresFile(fileDir) {
-  return Path.dirname(find(fileDir, '.eslintignore'))
-}
-
-export function getEslintFromDirectory(path) {
-  try {
-    return require(Path.join(path, 'lib', 'cli.js'))
-  } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
-      throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly')
-    } else throw e
-  }
-}
-
-let nodePrefixPath = null
 
 export function getNodePrefixPath() {
-  if (nodePrefixPath === null) {
+  if (Cache.NODE_PREFIX_PATH === null) {
     const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
     try {
-      nodePrefixPath = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
+      Cache.NODE_PREFIX_PATH = ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
     } catch (e) {
       throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly')
     }
   }
-  return nodePrefixPath
+  return Cache.NODE_PREFIX_PATH
 }
 
-let bundledEslintDirectory = null
-
-export function getBundledEslintDirectory() {
-  if (bundledEslintDirectory === null) {
-    bundledEslintDirectory = Path.normalize(Path.join(__dirname, '..', 'node_modules', 'eslint'))
-  }
-  return bundledEslintDirectory
-}
-
-export function getEslintDirectory(params, modulesPath = null) {
-  if (params.global) {
-    const prefixPath = getNodePrefixPath()
-    if (process.platform === 'win32') {
-      return Path.join(params.nodePath || prefixPath, 'node_modules', 'eslint')
-    }
-    return Path.join(params.nodePath || prefixPath, 'lib', 'node_modules', 'eslint')
-  }
-  const eslintPath = Path.join(modulesPath || getModulesDirectory(params.fileDir), 'eslint')
-  try {
-    FS.accessSync(eslintPath, FS.R_OK)
-    return eslintPath
-  } catch (_) {
-    return getBundledEslintDirectory()
-  }
-}
-
-export function getEslintConfig(params) {
-  const configFile = find(params.fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']) || null
+export function getConfigPath(fileDir) {
+  const configFile = findCached(fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc'])
   if (configFile) {
     return configFile
   }
 
-  const packagePath = find(params.fileDir, 'package.json')
+  const packagePath = findCached(fileDir, 'package.json')
   if (packagePath && Boolean(require(packagePath).eslintConfig)) {
     return packagePath
   }
-
-  if (params.canDisable) {
-    return null
-  }
-
-  if (params.configFile) {
-    return params.configFile
-  }
+  return null
 }

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -7,7 +7,7 @@ import resolveEnv from 'resolve-env'
 import {findCached} from 'atom-linter'
 
 const Cache = {
-  ESLINT_LOCAL_PATH: Path.normalize(__dirname, '..', 'node_modules', 'eslint'),
+  ESLINT_LOCAL_PATH: Path.normalize(Path.join(__dirname, '..', 'node_modules', 'eslint')),
   NODE_PREFIX_PATH: null,
   LAST_MODULES_PATH: null
 }
@@ -29,10 +29,7 @@ export function getESLintFromDirectory(modulesDir, config) {
       ESLintDirectory = Path.join(prefixPath, 'lib', 'node_modules', 'eslint')
     }
   } else {
-    if (modulesDir === null) {
-      throw new Error('Cannot find module `eslint`')
-    }
-    ESLintDirectory = Path.join(modulesDir, 'eslint')
+    ESLintDirectory = Path.join(modulesDir || '', 'eslint')
   }
   try {
     return require(Path.join(ESLintDirectory, 'lib', 'cli.js'))
@@ -40,7 +37,7 @@ export function getESLintFromDirectory(modulesDir, config) {
     if (config.useGlobalEslint && e.code === 'MODULE_NOT_FOUND') {
       throw new Error('ESLint not found, Please install or make sure Atom is getting $PATH correctly')
     }
-    return require(Cache.ESLINT_LOCAL_PATH)
+    return require(Path.join(Cache.ESLINT_LOCAL_PATH, 'lib', 'cli.js'))
   }
 }
 
@@ -91,9 +88,7 @@ export function getRelativePath(fileDir, filePath, config) {
 }
 
 export function getArgv(config, filePath, fileDir, configPath) {
-  if (configPath === null && config.disableWhenNoEslintConfig) {
-    return []
-  } else {
+  if (configPath === null) {
     configPath = config.eslintrcPath || null
   }
   const argv = [

--- a/src/worker.js
+++ b/src/worker.js
@@ -5,10 +5,14 @@ process.title = 'linter-eslint helper'
 import Path from 'path'
 import * as Helpers from './worker-helpers'
 import {create} from 'process-communication'
-import {findCached} from 'atom-linter'
+import {findCached, FindCache} from 'atom-linter'
 
 create().onRequest('job', function({contents, type, config, filePath}, job) {
   global.__LINTER_ESLINT_RESPONSE = []
+
+  if (config.disableFSCache) {
+    FindCache.clear()
+  }
 
   const fileDir = Path.dirname(filePath)
   const eslint = Helpers.getESLintInstance(fileDir, config)

--- a/src/worker.js
+++ b/src/worker.js
@@ -4,7 +4,7 @@ process.title = 'linter-eslint helper'
 
 import Path from 'path'
 import CP from 'childprocess-promise'
-import resolveEnv from 'resolve-end'
+import resolveEnv from 'resolve-env'
 import * as Helpers from './helpers'
 
 const Communication = new CP()
@@ -14,7 +14,7 @@ Communication.on('JOB', function(Job) {
 
   const params = Job.Message
   const ignoreFile = Helpers.getIgnoresFile(params.fileDir)
-  const configFile = Helpers.getEslintConfig(params.fileDir)
+  const configFile = Helpers.getEslintConfig(params.fileDir) || null
   const {eslint, eslintDirectory} = Helpers.getEslint(params)
 
   if (params.canDisable && configFile === null) {
@@ -64,7 +64,7 @@ Communication.on('JOB', function(Job) {
 Communication.on('FIX', function(Job) {
   const params = Job.Message
   const {eslint, eslintDirectory} = Helpers.getEslint(params)
-  const configFile = Helpers.getEslintConfig(params)
+  const configFile = Helpers.getEslintConfig(params) || null
 
   const argv = [
     process.execPath,

--- a/src/worker.js
+++ b/src/worker.js
@@ -22,13 +22,16 @@ create().onRequest('job', function({contents, type, config, filePath}, job) {
   const argv = Helpers.getArgv(config, relativeFilePath, fileDir, configPath)
 
   if (type === 'lint') {
-    job.response = lintJob(argv, contents, eslint)
+    job.response = lintJob(argv, contents, eslint, configPath, config)
   } else if (type === 'fix') {
     job.response = fixJob(argv, eslint)
   }
 })
 
-function lintJob(argv, contents, eslint) {
+function lintJob(argv, contents, eslint, configPath, config) {
+  if (configPath === null && config.disableWhenNoEslintConfig) {
+    return []
+  }
   eslint.execute(argv, contents)
   return global.__LINTER_ESLINT_RESPONSE
 }


### PR DESCRIPTION
Changes so far
 
- Log stuff to console as recieved instead of on exit
- Remove timeout from worker spawn
- Use module.exports instead of exports because babel 6's es6 default export is incompatible with commonjs

Fixes #364

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/373)
<!-- Reviewable:end -->
