### PR TITLE
EsLint rule: Indent two spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
         0,
         "never"
       ],
-      "comma-dangle": 0
+      "comma-dangle": 0,
+      "indent": [1, 2]
     },
     "extends": "airbnb/base",
     "parser": "babel-eslint",


### PR DESCRIPTION
As said in the Readme:
> Indent is 2 spaces

So why not add this as a ESLint rule?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/382)
<!-- Reviewable:end -->
