### PR TITLE
Revert "EsLint rule: Indent two spaces"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
         0,
         "never"
       ],
-      "comma-dangle": 0,
-      "indent": [1, 2]
+      "comma-dangle": 0
     },
     "extends": "airbnb/base",
     "parser": "babel-eslint",


### PR DESCRIPTION
Reverts AtomLinter/linter-eslint#382.

We are depending on `eslint-config-airbnb`, which [already specifies](https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v2.1.1/packages/eslint-config-airbnb/rules/style.js#L27) the indent rules. This PR overrode that specification with a much simpler version.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/384)
<!-- Reviewable:end -->
