### PR TITLE
Fix tests

### DIFF
--- a/spec/fixtures/files/good.js
+++ b/spec/fixtures/files/good.js
@@ -1,1 +1,1 @@
-'use strict';
+'use strict'

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -18,6 +18,7 @@ describe('The eslint provider for Linter', () => {
 
   beforeEach(() => {
     atom.config.set('linter-eslint.disableFSCache', false)
+    atom.config.set('linter-eslint.disableEslintIgnore', true)
     waitsForPromise(() =>
       atom.packages.activatePackage('language-javascript').then(() =>
         atom.workspace.open(goodPath)
@@ -28,12 +29,11 @@ describe('The eslint provider for Linter', () => {
   describe('checks bad.js and', () => {
     let editor = null
     beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-eslint.disableEslintIgnore', true)
-        return atom.workspace.open(badPath).then(openEditor => {
+      waitsForPromise(() =>
+        atom.workspace.open(badPath).then(openEditor => {
           editor = openEditor
         })
-      })
+      )
     })
 
     it('finds at least one message', () => {
@@ -95,6 +95,9 @@ describe('The eslint provider for Linter', () => {
   })
 
   describe('when a file is specified in an .eslintignore file', () => {
+    beforeEach(() => {
+      atom.config.set('linter-eslint.disableEslintIgnore', false)
+    })
     it('will not give warnings for the file', () => {
       waitsForPromise(() =>
         atom.workspace.open(ignoredPath).then(editor =>

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -36,26 +36,30 @@ describe('The eslint provider for Linter', () => {
       })
     })
 
-    it('finds at least one message', () =>
-      lint(editor).then(messages =>
-        expect(messages.length).toBeGreaterThan(0)
+    it('finds at least one message', () => {
+      waitsForPromise(() =>
+        lint(editor).then(messages => {
+          expect(messages.length).toBeGreaterThan(0)
+        })
       )
-    )
+    })
 
-    it('verifies that message', () =>
-      lint(editor).then(messages => {
-        expect(messages[0].type).toBeDefined()
-        expect(messages[0].type).toEqual('Error')
-        expect(messages[0].html).not.toBeDefined()
-        expect(messages[0].text).toBeDefined()
-        expect(messages[0].text).toEqual('"foo" is not defined.')
-        expect(messages[0].filePath).toBeDefined()
-        expect(messages[0].filePath).toMatch(/.+spec[\\\/]fixtures[\\\/]files[\\\/]bad\.js$/)
-        expect(messages[0].range).toBeDefined()
-        expect(messages[0].range.length).toEqual(2)
-        expect(messages[0].range).toEqual([[0, 0], [0, 9]])
-      })
-    )
+    it('verifies that message', () => {
+      waitsForPromise(() =>
+        lint(editor).then(messages => {
+          expect(messages[0].type).toBeDefined()
+          expect(messages[0].type).toEqual('Error')
+          expect(messages[0].html).not.toBeDefined()
+          expect(messages[0].text).toBeDefined()
+          expect(messages[0].text).toEqual('"foo" is not defined.')
+          expect(messages[0].filePath).toBeDefined()
+          expect(messages[0].filePath).toMatch(/.+spec[\\\/]fixtures[\\\/]files[\\\/]bad\.js$/)
+          expect(messages[0].range).toBeDefined()
+          expect(messages[0].range.length).toEqual(2)
+          expect(messages[0].range).toEqual([[0, 0], [0, 9]])
+        })
+      )
+    })
   })
 
   it('finds nothing wrong with an empty file', () => {


### PR DESCRIPTION
- Add missing `waitsForPromise` wrappers -- without these, test failures can get misattributed or ignored altogether
- Set the `disableEslintIgnore` setting to `true` for all tests, except the one that actually tests it. Otherwise the "finds nothing wrong" tests are useless. This can be demonstrated by reverting my changes to `good.js` -- it actually did contain a lint error :stuck_out_tongue:

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/413)
<!-- Reviewable:end -->
