### PR TITLE
Force an apt update

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ dependencies:
   override:
     - curl -L https://atom.io/download/deb -o atom-amd64.deb
     - sudo dpkg --install atom-amd64.deb || true
+    - sudo apt-get update
     - sudo apt-get -f install -y
     - apm install
 test:


### PR DESCRIPTION
Not all mirrors are serving the older package versions, so the builds are failing due to 404s.

See an example here: https://circleci.com/gh/AtomLinter/linter-eslint/292

This issue has only affected a few builds so far, but will get worse and worse as the mirrors diverge more from what the old database on the CircleCI containers are expecting.