### PR TITLE
add link to eslint rule in message

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.spawnWorker = spawnWorker;
 exports.showError = showError;
+exports.ruleURI = ruleURI;
 
 var _child_process = require('child_process');
 
@@ -57,4 +58,8 @@ function showError(givenMessage) {
     detail: detail,
     dismissable: true
   });
+}
+
+function ruleURI(ruleId) {
+  return `http://eslint.org/docs/rules/${ ruleId }`;
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -182,7 +182,9 @@ module.exports = {
               range: range
             };
             if (showRule) {
-              ret.html = '<span class="badge badge-flexible">' + `${ ruleId || 'Fatal' }</span>${ (0, _escapeHtml2.default)(message) }`;
+              const elName = ruleId ? 'a' : 'span';
+              const href = ruleId ? ` href=${ (0, _helpers.ruleURI)(ruleId) }` : '';
+              ret.html = `<${ elName }${ href } class="badge badge-flexible">` + `${ ruleId || 'Fatal' }</${ elName }> ${ (0, _escapeHtml2.default)(message) }`;
             } else {
               ret.text = message;
             }

--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -28,6 +28,8 @@ var _atomLinter = require('atom-linter');
 
 var _consistentPath = require('consistent-path');
 
+var _consistentPath2 = _interopRequireDefault(_consistentPath);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const Cache = {
@@ -49,7 +51,7 @@ function getNodePrefixPath() {
     const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     try {
       Cache.NODE_PREFIX_PATH = _child_process2.default.spawnSync(npmCommand, ['get', 'prefix'], {
-        env: assign(assign({}, process.env), { PATH: (0, _consistentPath.getPath)() })
+        env: assign(assign({}, process.env), { PATH: (0, _consistentPath2.default)() })
       }).output[1].toString().trim();
     } catch (e) {
       throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,3 +42,7 @@ export function showError(givenMessage, givenDetail = null) {
     dismissable: true
   })
 }
+
+export function ruleURI(ruleId) {
+  return `http://eslint.org/docs/rules/${ruleId}`
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,6 @@ import { CompositeDisposable, Range } from 'atom'
 import { spawnWorker, showError, ruleURI } from './helpers'
 import escapeHTML from 'escape-html'
 
-
-
 module.exports = {
   config: {
     lintHtmlFiles: {

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,10 @@
 'use babel'
 
 import { CompositeDisposable, Range } from 'atom'
-import { spawnWorker, showError } from './helpers'
+import { spawnWorker, showError, ruleURI } from './helpers'
 import escapeHTML from 'escape-html'
+
+
 
 module.exports = {
   config: {
@@ -164,8 +166,10 @@ module.exports = {
               range
             }
             if (showRule) {
-              ret.html = '<span class="badge badge-flexible">' +
-                `${ruleId || 'Fatal'}</span>${escapeHTML(message)}`
+              const elName = ruleId ? 'a' : 'span'
+              const href = ruleId ? ` href=${ruleURI(ruleId)}` : ''
+              ret.html = `<${elName}${href} class="badge badge-flexible">` +
+                `${ruleId || 'Fatal'}</${elName}> ${escapeHTML(message)}`
             } else {
               ret.text = message
             }


### PR DESCRIPTION
User can now click the link in the linter message to see the rule
definition on the eslint site.

Also added a missing space between the rule span and the rule message.

The only side-effect I'm aware of is that css for my theme styles links
close in color to the badge, as seen in this screenshot:
http://cl.ly/2O2o0Y2o0O3L. However, the rule at the bottom looks good,
again in my theme (One Dark).