### PR TITLE
Feat link to rule definition

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.spawnWorker = spawnWorker;
 exports.showError = showError;
+exports.ruleURI = ruleURI;
 
 var _child_process = require('child_process');
 
@@ -57,4 +58,8 @@ function showError(givenMessage) {
     detail: detail,
     dismissable: true
   });
+}
+
+function ruleURI(ruleId) {
+  return 'http://eslint.org/docs/rules/' + ruleId;
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -182,7 +182,9 @@ module.exports = {
               range: range
             };
             if (showRule) {
-              ret.html = '<span class="badge badge-flexible">' + ((ruleId || 'Fatal') + '</span>' + (0, _escapeHtml2.default)(message));
+              var elName = ruleId ? 'a' : 'span';
+              var href = ruleId ? ' href=' + (0, _helpers.ruleURI)(ruleId) : '';
+              ret.html = '<' + elName + href + ' class="badge badge-flexible">' + ((ruleId || 'Fatal') + '</' + elName + '> ' + (0, _escapeHtml2.default)(message));
             } else {
               ret.text = message;
             }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,3 +42,7 @@ export function showError(givenMessage, givenDetail = null) {
     dismissable: true
   })
 }
+
+export function ruleURI(ruleId) {
+  return `http://eslint.org/docs/rules/${ruleId}`
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 'use babel'
 
 import { CompositeDisposable, Range } from 'atom'
-import { spawnWorker, showError } from './helpers'
+import { spawnWorker, showError, ruleURI } from './helpers'
 import escapeHTML from 'escape-html'
 
 module.exports = {
@@ -164,8 +164,10 @@ module.exports = {
               range
             }
             if (showRule) {
-              ret.html = '<span class="badge badge-flexible">' +
-                `${ruleId || 'Fatal'}</span>${escapeHTML(message)}`
+              const elName = ruleId ? 'a' : 'span'
+              const href = ruleId ? ` href=${ruleURI(ruleId)}` : ''
+              ret.html = `<${elName}${href} class="badge badge-flexible">` +
+                `${ruleId || 'Fatal'}</${elName}> ${escapeHTML(message)}`
             } else {
               ret.text = message
             }


### PR DESCRIPTION
User can now click the rule name to view the rule on the eslint website in their browser.

![clickable eslint rule](https://cloud.githubusercontent.com/assets/133823/13619072/3d6efb90-e555-11e5-83ea-0eb6ae8f168c.png)

The only issue is the color of the rule at the cursor, but that should probably be fixed in `linter-ui-default`, not here.