### PR TITLE
Pin eslint version

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -20,14 +20,14 @@ var _path = require('path');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function spawnWorker() {
-  const env = Object.create(process.env);
+  var env = Object.create(process.env);
 
   delete env.NODE_PATH;
   delete env.NODE_ENV;
   delete env.OS;
 
-  const child = _child_process2.default.fork((0, _path.join)(__dirname, 'worker.js'), [], { env: env, silent: true });
-  const worker = (0, _processCommunication.createFromProcess)(child);
+  var child = _child_process2.default.fork((0, _path.join)(__dirname, 'worker.js'), [], { env: env, silent: true });
+  var worker = (0, _processCommunication.createFromProcess)(child);
 
   child.stdout.on('data', function (chunk) {
     console.log('[Linter-ESLint] STDOUT', chunk.toString());
@@ -42,10 +42,10 @@ function spawnWorker() {
 }
 
 function showError(givenMessage) {
-  let givenDetail = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
+  var givenDetail = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
 
-  let detail;
-  let message;
+  var detail = void 0;
+  var message = void 0;
   if (message instanceof Error) {
     detail = message.stack;
     message = message.message;
@@ -53,7 +53,7 @@ function showError(givenMessage) {
     detail = givenDetail;
     message = givenMessage;
   }
-  atom.notifications.addError(`[Linter-ESLint] ${ message }`, {
+  atom.notifications.addError('[Linter-ESLint] ' + message, {
     detail: detail,
     dismissable: true
   });

--- a/lib/main.js
+++ b/lib/main.js
@@ -65,7 +65,7 @@ module.exports = {
       default: false
     }
   },
-  activate: function () {
+  activate: function activate() {
     var _this = this;
 
     require('atom-package-deps').install();
@@ -75,7 +75,7 @@ module.exports = {
     this.worker = null;
     this.scopes = ['source.js', 'source.jsx', 'source.js.jsx', 'source.babel', 'source.js-semantic'];
 
-    const embeddedScope = 'source.js.embedded.html';
+    var embeddedScope = 'source.js.embedded.html';
     this.subscriptions.add(atom.config.observe('linter-eslint.lintHtmlFiles', function (lintHtmlFiles) {
       if (lintHtmlFiles) {
         _this.scopes.push(embeddedScope);
@@ -86,9 +86,9 @@ module.exports = {
       }
     }));
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
-      'linter-eslint:fix-file': function () {
-        const textEditor = atom.workspace.getActiveTextEditor();
-        const filePath = textEditor.getPath();
+      'linter-eslint:fix-file': function linterEslintFixFile() {
+        var textEditor = atom.workspace.getActiveTextEditor();
+        var filePath = textEditor.getPath();
 
         if (!textEditor || textEditor.isModified()) {
           // Abort for invalid or unsaved text editors
@@ -108,11 +108,11 @@ module.exports = {
       }
     }));
 
-    const initializeWorker = function () {
+    var initializeWorker = function initializeWorker() {
       var _spawnWorker = (0, _helpers.spawnWorker)();
 
-      const worker = _spawnWorker.worker;
-      const subscription = _spawnWorker.subscription;
+      var worker = _spawnWorker.worker;
+      var subscription = _spawnWorker.subscription;
 
       _this.worker = worker;
       _this.subscriptions.add(subscription);
@@ -125,26 +125,26 @@ module.exports = {
     };
     initializeWorker();
   },
-  deactivate: function () {
+  deactivate: function deactivate() {
     this.active = false;
     this.subscriptions.dispose();
   },
-  provideLinter: function () {
+  provideLinter: function provideLinter() {
     var _this2 = this;
 
-    const Helpers = require('atom-linter');
+    var Helpers = require('atom-linter');
     return {
       name: 'ESLint',
       grammarScopes: this.scopes,
       scope: 'file',
       lintOnFly: true,
-      lint: function (textEditor) {
-        const text = textEditor.getText();
+      lint: function lint(textEditor) {
+        var text = textEditor.getText();
         if (text.length === 0) {
           return Promise.resolve([]);
         }
-        const filePath = textEditor.getPath();
-        const showRule = atom.config.get('linter-eslint.showRuleIdInMessage');
+        var filePath = textEditor.getPath();
+        var showRule = atom.config.get('linter-eslint.showRuleIdInMessage');
 
         return _this2.worker.request('job', {
           contents: text,
@@ -153,36 +153,36 @@ module.exports = {
           filePath: filePath
         }).then(function (response) {
           return response.map(function (_ref) {
-            let message = _ref.message;
-            let line = _ref.line;
-            let severity = _ref.severity;
-            let ruleId = _ref.ruleId;
-            let column = _ref.column;
-            let fix = _ref.fix;
+            var message = _ref.message;
+            var line = _ref.line;
+            var severity = _ref.severity;
+            var ruleId = _ref.ruleId;
+            var column = _ref.column;
+            var fix = _ref.fix;
 
-            const textBuffer = textEditor.getBuffer();
-            let linterFix = null;
+            var textBuffer = textEditor.getBuffer();
+            var linterFix = null;
             if (fix) {
-              const fixRange = new _atom.Range(textBuffer.positionForCharacterIndex(fix.range[0]), textBuffer.positionForCharacterIndex(fix.range[1]));
+              var fixRange = new _atom.Range(textBuffer.positionForCharacterIndex(fix.range[0]), textBuffer.positionForCharacterIndex(fix.range[1]));
               linterFix = {
                 range: fixRange,
                 newText: fix.text
               };
             }
-            const range = Helpers.rangeFromLineNumber(textEditor, line - 1);
+            var range = Helpers.rangeFromLineNumber(textEditor, line - 1);
             if (column) {
               range[0][1] = column - 1;
             }
             if (column > range[1][1]) {
               range[1][1] = column - 1;
             }
-            const ret = {
+            var ret = {
               filePath: filePath,
               type: severity === 1 ? 'Warning' : 'Error',
               range: range
             };
             if (showRule) {
-              ret.html = '<span class="badge badge-flexible">' + `${ ruleId || 'Fatal' }</span>${ (0, _escapeHtml2.default)(message) }`;
+              ret.html = '<span class="badge badge-flexible">' + ((ruleId || 'Fatal') + '</span>' + (0, _escapeHtml2.default)(message));
             } else {
               ret.text = message;
             }

--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -32,13 +32,13 @@ var _consistentPath2 = _interopRequireDefault(_consistentPath);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const Cache = {
+var Cache = {
   ESLINT_LOCAL_PATH: _path2.default.normalize(_path2.default.join(__dirname, '..', 'node_modules', 'eslint')),
   NODE_PREFIX_PATH: null,
   LAST_MODULES_PATH: null
 };
-const assign = Object.assign || function (target, source) {
-  for (const key in source) {
+var assign = Object.assign || function (target, source) {
+  for (var key in source) {
     if (source.hasOwnProperty(key)) {
       target[key] = source[key];
     }
@@ -48,7 +48,7 @@ const assign = Object.assign || function (target, source) {
 
 function getNodePrefixPath() {
   if (Cache.NODE_PREFIX_PATH === null) {
-    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    var npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     try {
       Cache.NODE_PREFIX_PATH = _child_process2.default.spawnSync(npmCommand, ['get', 'prefix'], {
         env: assign(assign({}, process.env), { PATH: (0, _consistentPath2.default)() })
@@ -61,10 +61,10 @@ function getNodePrefixPath() {
 }
 
 function getESLintFromDirectory(modulesDir, config) {
-  let ESLintDirectory = null;
+  var ESLintDirectory = null;
 
   if (config.useGlobalEslint) {
-    const prefixPath = config.globalNodePath || getNodePrefixPath();
+    var prefixPath = config.globalNodePath || getNodePrefixPath();
     if (process.platform === 'win32') {
       ESLintDirectory = _path2.default.join(prefixPath, 'node_modules', 'eslint');
     } else {
@@ -92,18 +92,18 @@ function refreshModulesPath(modulesDir) {
 }
 
 function getESLintInstance(fileDir, config) {
-  const modulesDir = _path2.default.dirname((0, _atomLinter.findCached)(fileDir, 'node_modules/eslint'));
+  var modulesDir = _path2.default.dirname((0, _atomLinter.findCached)(fileDir, 'node_modules/eslint'));
   refreshModulesPath(modulesDir);
   return getESLintFromDirectory(modulesDir, config);
 }
 
 function getConfigPath(fileDir) {
-  const configFile = (0, _atomLinter.findCached)(fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']);
+  var configFile = (0, _atomLinter.findCached)(fileDir, ['.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']);
   if (configFile) {
     return configFile;
   }
 
-  const packagePath = (0, _atomLinter.findCached)(fileDir, 'package.json');
+  var packagePath = (0, _atomLinter.findCached)(fileDir, 'package.json');
   if (packagePath && Boolean(require(packagePath).eslintConfig)) {
     return packagePath;
   }
@@ -111,10 +111,10 @@ function getConfigPath(fileDir) {
 }
 
 function getRelativePath(fileDir, filePath, config) {
-  const ignoreFile = config.disableEslintIgnore ? null : (0, _atomLinter.findCached)(fileDir, '.eslintignore');
+  var ignoreFile = config.disableEslintIgnore ? null : (0, _atomLinter.findCached)(fileDir, '.eslintignore');
 
   if (ignoreFile) {
-    const ignoreDir = _path2.default.dirname(ignoreFile);
+    var ignoreDir = _path2.default.dirname(ignoreFile);
     process.chdir(ignoreDir);
     return _path2.default.relative(ignoreDir, filePath);
   }
@@ -123,12 +123,12 @@ function getRelativePath(fileDir, filePath, config) {
 }
 
 function getArgv(type, config, filePath, fileDir, givenConfigPath) {
-  let configPath;
+  var configPath = void 0;
   if (givenConfigPath === null) {
     configPath = config.eslintrcPath || null;
   } else configPath = givenConfigPath;
 
-  const argv = [process.execPath, 'a-b-c' // dummy value for eslint executable
+  var argv = [process.execPath, 'a-b-c' // dummy value for eslint executable
   ];
   if (type === 'lint') {
     argv.push('--stdin');
@@ -136,7 +136,7 @@ function getArgv(type, config, filePath, fileDir, givenConfigPath) {
   argv.push('--format', _path2.default.join(__dirname, 'reporter.js'));
 
   if (config.eslintRulesDir) {
-    let rulesDir = (0, _resolveEnv2.default)(config.eslintRulesDir);
+    var rulesDir = (0, _resolveEnv2.default)(config.eslintRulesDir);
     if (!_path2.default.isAbsolute(rulesDir)) {
       rulesDir = (0, _atomLinter.findCached)(fileDir, rulesDir);
     }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -20,8 +20,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 process.title = 'linter-eslint helper';
 
-const ignoredMessageV1 = 'File ignored because of your .eslintignore file. Use --no-ignore to override.';
-const ignoredMessageV2 = 'File ignored because of a matching ignore pattern. Use --no-ignore to override.';
+var ignoredMessageV1 = 'File ignored because of your .eslintignore file. Use --no-ignore to override.';
+var ignoredMessageV2 = 'File ignored because of a matching ignore pattern. Use --no-ignore to override.';
 
 function lintJob(argv, contents, eslint, configPath, config) {
   if (configPath === null && config.disableWhenNoEslintConfig) {
@@ -44,10 +44,10 @@ function fixJob(argv, eslint) {
 }
 
 (0, _processCommunication.create)().onRequest('job', function (_ref, job) {
-  let contents = _ref.contents;
-  let type = _ref.type;
-  let config = _ref.config;
-  let filePath = _ref.filePath;
+  var contents = _ref.contents;
+  var type = _ref.type;
+  var config = _ref.config;
+  var filePath = _ref.filePath;
 
   global.__LINTER_ESLINT_RESPONSE = [];
 
@@ -55,12 +55,12 @@ function fixJob(argv, eslint) {
     _atomLinter.FindCache.clear();
   }
 
-  const fileDir = _path2.default.dirname(filePath);
-  const eslint = Helpers.getESLintInstance(fileDir, config);
-  const configPath = Helpers.getConfigPath(fileDir);
-  const relativeFilePath = Helpers.getRelativePath(fileDir, filePath, config);
+  var fileDir = _path2.default.dirname(filePath);
+  var eslint = Helpers.getESLintInstance(fileDir, config);
+  var configPath = Helpers.getConfigPath(fileDir);
+  var relativeFilePath = Helpers.getRelativePath(fileDir, filePath, config);
 
-  const argv = Helpers.getArgv(type, config, relativeFilePath, fileDir, configPath);
+  var argv = Helpers.getArgv(type, config, relativeFilePath, fileDir, configPath);
 
   if (type === 'lint') {
     job.response = lintJob(argv, contents, eslint, configPath, config);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "atom-package-deps": "^4.0.1",
     "consistent-path": "^2.0.1",
     "escape-html": "^1.0.3",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "process-communication": "^1.1.0",
     "resolve-env": "^1.0.0"
   },


### PR DESCRIPTION
Pin the eslint version as a few other bugs are being held back in diagnosis due to CI failing. If users need a newer version one locally installed in their project will work.

This can be removed once `babel-eslint` and `eslint@2.3.0` figure out what they are going to do...