### PR TITLE
Pass ignore file to eslint explicitly

### DIFF
--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -135,6 +135,11 @@ function getArgv(type, config, filePath, fileDir, givenConfigPath) {
   }
   argv.push('--format', _path2.default.join(__dirname, 'reporter.js'));
 
+  var ignoreFile = config.disableEslintIgnore ? null : (0, _atomLinter.findCached)(fileDir, '.eslintignore');
+  if (ignoreFile) {
+    argv.push('--ignore-path', ignoreFile);
+  }
+
   if (config.eslintRulesDir) {
     var rulesDir = (0, _resolveEnv2.default)(config.eslintRulesDir);
     if (!_path2.default.isAbsolute(rulesDir)) {

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -119,6 +119,11 @@ export function getArgv(type, config, filePath, fileDir, givenConfigPath) {
   }
   argv.push('--format', Path.join(__dirname, 'reporter.js'))
 
+  const ignoreFile = config.disableEslintIgnore ? null : findCached(fileDir, '.eslintignore')
+  if (ignoreFile) {
+    argv.push('--ignore-path', ignoreFile)
+  }
+
   if (config.eslintRulesDir) {
     let rulesDir = resolveEnv(config.eslintRulesDir)
     if (!Path.isAbsolute(rulesDir)) {


### PR DESCRIPTION
Fixes #448 

I honestly have no idea why ESLint is not finding the `.eslintignore` file on its own sometimes.  Sometimes it does, and sometimes it doesn't.  With these changes, if we find a `.eslintignore` file, we will pass it to ESLint with the `--ignore-path` arg, to be sure it's picked up.