### PR TITLE
Remove useless getPath from getNodePrefixPath.

### DIFF
--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -50,9 +50,7 @@ function getNodePrefixPath() {
   if (Cache.NODE_PREFIX_PATH === null) {
     var npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     try {
-      Cache.NODE_PREFIX_PATH = _child_process2.default.spawnSync(npmCommand, ['get', 'prefix'], {
-        env: assign(assign({}, process.env), { PATH: (0, _consistentPath2.default)() })
-      }).output[1].toString().trim();
+      Cache.NODE_PREFIX_PATH = _child_process2.default.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim();
     } catch (e) {
       throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly');
     }

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -25,9 +25,7 @@ export function getNodePrefixPath() {
     const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
     try {
       Cache.NODE_PREFIX_PATH =
-        ChildProcess.spawnSync(npmCommand, ['get', 'prefix'], {
-          env: assign(assign({}, process.env), { PATH: getPath() })
-        }).output[1].toString().trim()
+        ChildProcess.spawnSync(npmCommand, ['get', 'prefix']).output[1].toString().trim()
     } catch (e) {
       throw new Error(
         'Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly'


### PR DESCRIPTION
getNodePrefixPath is called when seGlobalEslint is enabled and
globalNodePath is empty. In global setup the PATH contains the path
for the npm executable and it is useless injecting it in the env again.

Fix #484