### PR TITLE
Add `Fix on Save option` to fix lint errors on save ( fixes #417)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -63,6 +63,12 @@ module.exports = {
       description: 'Paths of node_modules, .eslintignore and others are cached',
       type: 'boolean',
       default: false
+    },
+    fixOnSave: {
+      title: 'Fix errors on save',
+      description: 'Everytime the file is saved, linter-eslint tries to fix errors',
+      type: 'boolean',
+      default: false
     }
   },
   activate: function activate() {
@@ -85,6 +91,19 @@ module.exports = {
         }
       }
     }));
+    this.subscriptions.add(atom.workspace.observeTextEditors(function (editor) {
+      editor.onDidSave(function () {
+        if (atom.config.get('linter-eslint.fixOnSave')) {
+          _this.worker.request('job', {
+            type: 'fix',
+            config: atom.config.get('linter-eslint'),
+            filePath: editor.getPath()
+          }).catch(function (response) {
+            return atom.notifications.addWarning(response);
+          });
+        }
+      });
+    }));
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'linter-eslint:fix-file': function linterEslintFixFile() {
         var textEditor = atom.workspace.getActiveTextEditor();
@@ -95,7 +114,6 @@ module.exports = {
           atom.notifications.addError('Linter-ESLint: Please save before fixing');
           return;
         }
-
         _this.worker.request('job', {
           type: 'fix',
           config: atom.config.get('linter-eslint'),

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -141,4 +141,23 @@ describe('The eslint provider for Linter', () => {
       )
     })
   })
+
+  describe('Fix errors when saved', () => {
+    beforeEach(() => {
+      atom.config.set('linter-eslint.fixOnSave', true)
+    })
+    it('should fix lint errors when saved', () => {
+      waitsForPromise(() =>
+        atom.workspace.open(fixPath).then(editor => {
+          lint(editor).then(messages => {
+            expect(messages.length).toEqual(2)
+            editor.save()
+            lint(editor).then(messagesAfterSave => {
+              expect(messagesAfterSave.length).toEqual(0)
+            })
+          })
+        })
+      )
+    })
+  })
 })

--- a/src/main.js
+++ b/src/main.js
@@ -56,6 +56,12 @@ module.exports = {
       description: 'Paths of node_modules, .eslintignore and others are cached',
       type: 'boolean',
       default: false
+    },
+    fixOnSave: {
+      title: 'Fix errors on save',
+      description: 'Have eslint attempt to fix some errors automatically when saving the file.',
+      type: 'boolean',
+      default: false
     }
   },
   activate() {
@@ -75,6 +81,19 @@ module.exports = {
           this.scopes.splice(this.scopes.indexOf(embeddedScope), 1)
         }
       }
+    }))
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      editor.onDidSave(() => {
+        if (atom.config.get('linter-eslint.fixOnSave')) {
+          this.worker.request('job', {
+            type: 'fix',
+            config: atom.config.get('linter-eslint'),
+            filePath: editor.getPath()
+          }).catch((response) =>
+            atom.notifications.addWarning(response)
+          )
+        }
+      })
     }))
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'linter-eslint:fix-file': () => {


### PR DESCRIPTION
~~**DO NOT MERGE** 
Need to fix the unit test . I could not figure out how to write the unit test which checks something after the file is saved. I used setTimeOut as an ugly hack , but somone please help.~~
I wish to handle unit tests in another task if its fine. Otherwise we can keep this pull request open for a while till we can get the unit test . 

**Main change** : 

1. Added new option (`boolean`) to check if we need to fix the errors on save. Default is `false`
![image](https://cloud.githubusercontent.com/assets/1425006/14058245/5e0456ea-f340-11e5-999b-92d2f20cec43.png)

2. Everytime a file is opened, an observer to save event is added, on save we check if config is true then call fix errors job
3. If fixing is success, we stay quiet . If an exceptions happens, we report .