### PR TITLE
Allow ~/ in path to ESLint Rules Dir (fixes #441)

### DIFF
--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -30,6 +30,10 @@ var _consistentPath = require('consistent-path');
 
 var _consistentPath2 = _interopRequireDefault(_consistentPath);
 
+var _untildify = require('untildify');
+
+var _untildify2 = _interopRequireDefault(_untildify);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var Cache = {
@@ -135,7 +139,14 @@ function getArgv(type, config, filePath, fileDir, givenConfigPath) {
   if (config.eslintRulesDir) {
     var rulesDir = (0, _resolveEnv2.default)(config.eslintRulesDir);
     if (!_path2.default.isAbsolute(rulesDir)) {
+      var splitPath = rulesDir.split('/');
+      if (splitPath[0] === '~') {
+        rulesDir = (0, _untildify2.default)(rulesDir);
+      }
       rulesDir = (0, _atomLinter.findCached)(fileDir, rulesDir);
+    }
+    if (!rulesDir) {
+      throw new Error('Invalid ESLint Rules Dir path');
     }
     argv.push('--rulesdir', rulesDir);
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm run lint && apm test",
     "lint": "eslint .",
     "watch": "ucompiler watch",
-    "compile": "ucompiler go"
+    "compile": "ucompiler go",
+    "test": "apm test"
   },
   "dependencies": {
     "atom-linter": "^4.3.4",
@@ -21,7 +22,8 @@
     "escape-html": "^1.0.3",
     "eslint": "^2.8.0",
     "process-communication": "^1.1.0",
-    "resolve-env": "^1.0.0"
+    "resolve-env": "^1.0.0",
+    "untildify": "^2.1.0"
   },
   "devDependencies": {
     "eslint-config-airbnb-base": "^1.0.3",

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -5,6 +5,7 @@ import ChildProcess from 'child_process'
 import resolveEnv from 'resolve-env'
 import { findCached } from 'atom-linter'
 import getPath from 'consistent-path'
+import untildify from 'untildify'
 
 const Cache = {
   ESLINT_LOCAL_PATH: Path.normalize(Path.join(__dirname, '..', 'node_modules', 'eslint')),
@@ -119,7 +120,14 @@ export function getArgv(type, config, filePath, fileDir, givenConfigPath) {
   if (config.eslintRulesDir) {
     let rulesDir = resolveEnv(config.eslintRulesDir)
     if (!Path.isAbsolute(rulesDir)) {
+      const splitPath = rulesDir.split('/')
+      if (splitPath[0] === '~') {
+        rulesDir = untildify(rulesDir)
+      }
       rulesDir = findCached(fileDir, rulesDir)
+    }
+    if (!rulesDir) {
+      throw new Error('Invalid ESLint Rules Dir path')
     }
     argv.push('--rulesdir', rulesDir)
   }


### PR DESCRIPTION
Took a crack at this - this works locally for me on a machine with OSX, but not currently able to test on a Windows or Linux machine. Not sure what is expected/necessary regarding tests. I didn't see any coverage for this particular function, but am happy to write some tests if need be.

The problem seems to be that `path.isAbsolute('~/path/to/rulesConfig')` returns `false`, and then the linter tries to resolve the path relative to `fileDir`. As a result, `rulesDir` has the value `null`, and it silently fails.

I actually can't seem to figure out how to run the current tests...Any help would be appreciated :smile: 