### PR TITLE
link react related rules to plugin docs

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -61,5 +61,12 @@ function showError(givenMessage) {
 }
 
 function ruleURI(ruleId) {
-  return 'http://eslint.org/docs/rules/' + ruleId;
+  var ruleParts = ruleId.split('/');
+  if (ruleParts.length === 1) {
+    return 'http://eslint.org/docs/rules/' + ruleId;
+  }
+  if (ruleParts[0] === 'react') {
+    return 'https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/' + ruleParts[1] + '.md';
+  }
+  return '';
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -44,5 +44,12 @@ export function showError(givenMessage, givenDetail = null) {
 }
 
 export function ruleURI(ruleId) {
-  return `http://eslint.org/docs/rules/${ruleId}`
+  const ruleParts = ruleId.split('/')
+  if (ruleParts.length === 1) {
+    return `http://eslint.org/docs/rules/${ruleId}`
+  }
+  if (ruleParts[0] === 'react') {
+    return `https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/${ruleParts[1]}.md`
+  }
+  return ''
 }


### PR DESCRIPTION
Links `react/` rules to https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules instead of a 404 page.