### PR TITLE
Fix: 'Fix on Save' should run only in valid file types

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -93,7 +93,7 @@ module.exports = {
     }));
     this.subscriptions.add(atom.workspace.observeTextEditors(function (editor) {
       editor.onDidSave(function () {
-        if (atom.config.get('linter-eslint.fixOnSave')) {
+        if (_this.scopes.indexOf(editor.getGrammar().scopeName) !== -1 && atom.config.get('linter-eslint.fixOnSave')) {
           _this.worker.request('job', {
             type: 'fix',
             config: atom.config.get('linter-eslint'),

--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,8 @@ module.exports = {
     }))
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
       editor.onDidSave(() => {
-        if (atom.config.get('linter-eslint.fixOnSave')) {
+        if (this.scopes.indexOf(editor.getGrammar().scopeName) !== -1 &&
+            atom.config.get('linter-eslint.fixOnSave')) {
           this.worker.request('job', {
             type: 'fix',
             config: atom.config.get('linter-eslint'),


### PR DESCRIPTION
We already have valid scopes listed as 

```js
this.scopes = ['source.js', 'source.jsx', 'source.js.jsx', 'source.babel', 'source.js-semantic']
```

I am using the same array and comparing if the file type belongs to one of them .
With this fix, it is not running in all file types. 
Please validate. 