### PR TITLE
Move to eslint-config-airbnb-base

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,6 +1,6 @@
-'use strict';
-// This file is used by eslint to hand the errors over to the worker
+"use strict";
 
+// This file is used by eslint to hand the errors over to the worker
 module.exports = function (results) {
   global.__LINTER_ESLINT_RESPONSE = results[0].messages;
 };

--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -37,21 +37,13 @@ var Cache = {
   NODE_PREFIX_PATH: null,
   LAST_MODULES_PATH: null
 };
-var assign = Object.assign || function (target, source) {
-  for (var key in source) {
-    if (source.hasOwnProperty(key)) {
-      target[key] = source[key];
-    }
-  }
-  return target;
-};
 
 function getNodePrefixPath() {
   if (Cache.NODE_PREFIX_PATH === null) {
     var npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     try {
       Cache.NODE_PREFIX_PATH = _child_process2.default.spawnSync(npmCommand, ['get', 'prefix'], {
-        env: assign(assign({}, process.env), { PATH: (0, _consistentPath2.default)() })
+        env: Object.assign(Object.assign({}, process.env), { PATH: (0, _consistentPath2.default)() })
       }).output[1].toString().trim();
     } catch (e) {
       throw new Error('Unable to execute `npm get prefix`. Please make sure Atom is getting $PATH correctly');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/AtomLinter/linter-eslint.git",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.4.0 <2.0.0"
   },
   "scripts": {
     "test": "npm run lint && apm test",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "atom": ">0.50.0"
   },
   "scripts": {
+    "test": "npm run lint && apm test",
     "lint": "eslint .",
     "watch": "ucompiler watch",
     "compile": "ucompiler go"
@@ -18,15 +19,13 @@
     "atom-package-deps": "^4.0.1",
     "consistent-path": "^2.0.1",
     "escape-html": "^1.0.3",
-    "eslint": "^2.7.0",
+    "eslint": "^2.8.0",
     "process-communication": "^1.1.0",
     "resolve-env": "^1.0.0"
   },
   "devDependencies": {
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-import": "^1.2.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
+    "eslint-config-airbnb-base": "^1.0.0",
+    "eslint-plugin-import": "^1.5.0",
     "ucompiler": "^3.2.0",
     "ucompiler-plugin-babel": "^3.0.0",
     "ucompiler-plugin-newline": "^3.0.0",
@@ -44,28 +43,16 @@
   },
   "eslintConfig": {
     "rules": {
-      "no-empty": 0,
       "no-console": 0,
-      "no-new": 0,
-      "no-extra-semi": 1,
-      "semi": [
-        2,
-        "never"
-      ],
+      "semi": [2, "never"],
       "func-names": 0,
-      "strict": [
-        0,
-        "never"
-      ],
-      "no-param-reassign": [
-        2,
-        {
-          "props": false
-        }
-      ],
-      "comma-dangle": 0
+      "no-param-reassign": [2, { "props": false }],
+      "comma-dangle": 0,
+      "no-underscore-dangle": 0,
+      "global-require": 0,
+      "import/no-unresolved": [2, { "ignore": ["atom"] }]
     },
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
     "globals": {
       "atom": "true"
     },

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,8 +1,6 @@
 {
-  "globals": {
-    "waitsForPromise": true
-  },
   "env": {
-    "jasmine": true
+    "jasmine": true,
+    "atomtest": true
   }
 }

--- a/spec/common.js
+++ b/spec/common.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const Path = require('path')
 
 module.exports.getFixturesPath = function (path) {

--- a/spec/fixtures/files/good.js
+++ b/spec/fixtures/files/good.js
@@ -1,1 +1,5 @@
-'use strict'
+function foo() {
+  return 42
+}
+
+foo()

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,4 +1,3 @@
-'use strict'
 // This file is used by eslint to hand the errors over to the worker
 module.exports = function (results) {
   global.__LINTER_ESLINT_RESPONSE = results[0].messages

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -11,14 +11,6 @@ const Cache = {
   NODE_PREFIX_PATH: null,
   LAST_MODULES_PATH: null
 }
-const assign = Object.assign || function (target, source) {
-  for (const key in source) {
-    if (source.hasOwnProperty(key)) {
-      target[key] = source[key]
-    }
-  }
-  return target
-}
 
 export function getNodePrefixPath() {
   if (Cache.NODE_PREFIX_PATH === null) {
@@ -26,7 +18,7 @@ export function getNodePrefixPath() {
     try {
       Cache.NODE_PREFIX_PATH =
         ChildProcess.spawnSync(npmCommand, ['get', 'prefix'], {
-          env: assign(assign({}, process.env), { PATH: getPath() })
+          env: Object.assign(Object.assign({}, process.env), { PATH: getPath() })
         }).output[1].toString().trim()
     } catch (e) {
       throw new Error(


### PR DESCRIPTION
Move to `eslint-config-airbnb-base` from `eslint-config-airbnb` as we don't need the React related stuff.

Updates the minimum Atom version to v1.4.0 so the `Object.assign()` polyfill can be removed. This could probably be earlier, but is there any reason to go further back?

Closes #540.
Closes #547.