### PR TITLE
Add URIs for documentation of plugins

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -61,5 +61,44 @@ function showError(givenMessage) {
 }
 
 function ruleURI(ruleId) {
-  return 'http://eslint.org/docs/rules/' + ruleId;
+  var ruleParts = ruleId.split('/');
+
+  if (ruleParts.length == 1) {
+    return 'http://eslint.org/docs/rules/' + ruleId;
+  }
+
+  switch (ruleParts[0]) {
+    case 'angular':
+      return 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/' + ruleParts[1] + '.md';
+
+    case 'ava':
+      return 'https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/' + ruleParts[1] + '.md'
+
+    case 'import':
+      return 'https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/' + ruleParts[1] + '.md';
+
+    case 'import-order':
+      return 'https://github.com/jfmengels/eslint-plugin-import-order/blob/master/docs/rules/' + ruleParts[1] + '.md';
+
+    case 'jasmine':
+      return 'https://github.com/tlvince/eslint-plugin-jasmine/blob/master/docs/rules/' + ruleParts[1] + '.md';
+
+    case 'jsx-a11y':
+      return 'https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/' + ruleParts[1] + '.md';
+
+    case 'lodash':
+      return 'https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/' + ruleParts[1] + '.md'
+
+    case 'mocha':
+      return 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/' + ruleParts[1] + '.md';
+
+    case 'promise':
+      return 'https://github.com/xjamundx/eslint-plugin-promise#' + ruleParts[1];
+
+    case 'react':
+      return 'https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/' + ruleParts[1] + '.md';
+
+    default:
+      return 'https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation';
+  }
 }


### PR DESCRIPTION
This makes the link to rule documentation work for the plugins used by the airbnb preset.