### PR TITLE
Add plugin rule switch statement to src

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -63,40 +63,42 @@ function showError(givenMessage) {
 function ruleURI(ruleId) {
   var ruleParts = ruleId.split('/');
 
-  if (ruleParts.length == 1) {
+  if (ruleParts.length === 1) {
     return 'http://eslint.org/docs/rules/' + ruleId;
   }
 
-  switch (ruleParts[0]) {
+  var pluginName = ruleParts[0];
+  var ruleName = ruleParts[1];
+  switch (pluginName) {
     case 'angular':
-      return 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/' + ruleParts[1] + '.md';
+      return 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/' + ruleName + '.md';
 
     case 'ava':
-      return 'https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/' + ruleParts[1] + '.md'
+      return 'https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'import':
-      return 'https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/' + ruleParts[1] + '.md';
+      return 'https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'import-order':
-      return 'https://github.com/jfmengels/eslint-plugin-import-order/blob/master/docs/rules/' + ruleParts[1] + '.md';
+      return 'https://github.com/jfmengels/eslint-plugin-import-order/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'jasmine':
-      return 'https://github.com/tlvince/eslint-plugin-jasmine/blob/master/docs/rules/' + ruleParts[1] + '.md';
+      return 'https://github.com/tlvince/eslint-plugin-jasmine/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'jsx-a11y':
-      return 'https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/' + ruleParts[1] + '.md';
+      return 'https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'lodash':
-      return 'https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/' + ruleParts[1] + '.md'
+      return 'https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'mocha':
-      return 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/' + ruleParts[1] + '.md';
+      return 'https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'promise':
-      return 'https://github.com/xjamundx/eslint-plugin-promise#' + ruleParts[1];
+      return 'https://github.com/xjamundx/eslint-plugin-promise#' + ruleName;
 
     case 'react':
-      return 'https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/' + ruleParts[1] + '.md';
+      return 'https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/' + ruleName + '.md';
 
     default:
       return 'https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -44,5 +44,46 @@ export function showError(givenMessage, givenDetail = null) {
 }
 
 export function ruleURI(ruleId) {
-  return `http://eslint.org/docs/rules/${ruleId}`
+  const ruleParts = ruleId.split('/')
+
+  if (ruleParts.length === 1) {
+    return `http://eslint.org/docs/rules/${ruleId}`
+  }
+
+  const pluginName = ruleParts[0]
+  const ruleName = ruleParts[1]
+  switch (pluginName) {
+    case 'angular':
+      return `https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/${ruleName}.md`
+
+    case 'ava':
+      return `https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/${ruleName}.md`
+
+    case 'import':
+      return `https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/${ruleName}.md`
+
+    case 'import-order':
+      return `https://github.com/jfmengels/eslint-plugin-import-order/blob/master/docs/rules/${ruleName}.md`
+
+    case 'jasmine':
+      return `https://github.com/tlvince/eslint-plugin-jasmine/blob/master/docs/rules/${ruleName}.md`
+
+    case 'jsx-a11y':
+      return `https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/${ruleName}.md`
+
+    case 'lodash':
+      return `https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/${ruleName}.md`
+
+    case 'mocha':
+      return `https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/${ruleName}.md`
+
+    case 'promise':
+      return `https://github.com/xjamundx/eslint-plugin-promise#${ruleName}`
+
+    case 'react':
+      return `https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/${ruleName}.md`
+
+    default:
+      return 'https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation'
+  }
 }


### PR DESCRIPTION
I merged #562 too quickly before realizing that there were no `src` file
changes, only changes to `lib`, which would have been overwritten the
first time someone else compiled `src` to `lib`.  This commit brings
@relekang’s contribution over to the `src` file with a few minor
modifications to meet our linting rules.