### PR TITLE
Clarified disableEslintIgnore description

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,7 +54,7 @@ module.exports = {
       default: ''
     },
     disableEslintIgnore: {
-      title: 'Disable using .eslintignore files',
+      title: 'Don\'t use .eslintignore files',
       type: 'boolean',
       default: false
     },

--- a/src/main.js
+++ b/src/main.js
@@ -47,7 +47,7 @@ module.exports = {
       default: ''
     },
     disableEslintIgnore: {
-      title: 'Disable using .eslintignore files',
+      title: 'Don\'t use .eslintignore files',
       type: 'boolean',
       default: false
     },


### PR DESCRIPTION
As brought up in https://github.com/AtomLinter/linter-eslint/issues/548, `Disable using .eslintignore files` is very ambiguous. It's not clear whether checking the box will "Disable (the use of) .eslintignore files," (which is actually what it's doing) or whether checking the box will "Disable (this package) using .eslintignore files" (which makes it appear to be a bug when this box isn't checked but the package still obeys `.eslintignore` files).