### PR TITLE
Update `eslint-plugin-ava` repository link

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -74,7 +74,7 @@ function ruleURI(ruleId) {
       return 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/' + ruleName + '.md';
 
     case 'ava':
-      return 'https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/' + ruleName + '.md';
+      return 'https://github.com/avajs/eslint-plugin-ava/blob/master/docs/rules/' + ruleName + '.md';
 
     case 'import':
       return 'https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/' + ruleName + '.md';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -57,7 +57,7 @@ export function ruleURI(ruleId) {
       return `https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/${ruleName}.md`
 
     case 'ava':
-      return `https://github.com/sindresorhus/eslint-plugin-ava/blob/master/docs/rules/${ruleName}.md`
+      return `https://github.com/avajs/eslint-plugin-ava/blob/master/docs/rules/${ruleName}.md`
 
     case 'import':
       return `https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/${ruleName}.md`


### PR DESCRIPTION
All AVA-related projects moved to a new organization named `avajs`, including this plugin. There is a redirection, but this should be better.