### PR TITLE
Add environment variable parsing

### DIFF
--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -117,7 +117,10 @@ function getRelativePath(fileDir, filePath, config) {
 function getArgv(type, config, filePath, fileDir, givenConfigPath) {
   var configPath = void 0;
   if (givenConfigPath === null) {
-    configPath = config.eslintrcPath || null;
+    var envVarPath = config.eslintrcPath.replace(/%([^%]+)%/g, function(_,n) {
+      return process.env[n];
+    });
+    configPath = envVarPath || null;
   } else configPath = givenConfigPath;
 
   var argv = [process.execPath, 'a-b-c' // dummy value for eslint executable

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -99,7 +99,10 @@ export function getRelativePath(fileDir, filePath, config) {
 export function getArgv(type, config, filePath, fileDir, givenConfigPath) {
   let configPath
   if (givenConfigPath === null) {
-    configPath = config.eslintrcPath || null
+    var envVarPath = config.eslintrcPath.replace(/%([^%]+)%/g, function(_,n) {
+      return process.env[n];
+    });
+    configPath = envVarPath || null;
   } else configPath = givenConfigPath
 
   const argv = [


### PR DESCRIPTION
This adds the ability to use environment variables in the _.eslintrc Path_ setting

Example: `%ATOM_HOME%\.eslintrc.json`