### PR TITLE
Add support for configs in nested package.json

### DIFF
--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -96,8 +96,11 @@ function getConfigPath(fileDir) {
   }
 
   var packagePath = (0, _atomLinter.findCached)(fileDir, 'package.json');
-  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
-    return packagePath;
+  while (packagePath) {
+    if (Boolean(require(packagePath).eslintConfig)) {
+      return packagePath;
+    }
+    packagePath = (0, _atomLinter.findCached)(_path2.default.join(fileDir, '..'));
   }
   return null;
 }

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -82,7 +82,7 @@ export function getConfigPath(fileDir) {
     if (Boolean(require(packagePath).eslintConfig)) {
       return packagePath
     }
-    packagePath = findCached(Path.join(fileDir, '..'))
+    packagePath = findCached(Path.join(fileDir, '..', 'package.json'))
   }
   return null
 }

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -77,9 +77,12 @@ export function getConfigPath(fileDir) {
     return configFile
   }
 
-  const packagePath = findCached(fileDir, 'package.json')
-  if (packagePath && Boolean(require(packagePath).eslintConfig)) {
-    return packagePath
+  let packagePath = findCached(fileDir, 'package.json')
+  while (packagePath) {
+    if (Boolean(require(packagePath).eslintConfig)) {
+      return packagePath
+    }
+    packagePath = findCached(Path.join(fileDir, '..'))
   }
   return null
 }


### PR DESCRIPTION
This allows projects with an eslintConfig key in the root package.json to work properly when they have other package.json in subfolders