### PR TITLE
Add eslint-plugin-standard rule docs link

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -100,6 +100,9 @@ function ruleURI(ruleId) {
     case 'react':
       return 'https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/' + ruleName + '.md';
 
+    case 'standard':
+      return 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations';
+
     default:
       return 'https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation';
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -83,6 +83,9 @@ export function ruleURI(ruleId) {
     case 'react':
       return `https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/${ruleName}.md`
 
+    case 'standard':
+      return 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+
     default:
       return 'https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation'
   }


### PR DESCRIPTION
This package is currently missing docs links for [eslint-plugin-standard](https://github.com/xjamundx/eslint-plugin-standard#rules-explanations) so I'm adding them! The specific rule I hit was `standard/array-bracket-even-spacing`.

(I got here from https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation#adding-rule-doc-links.)