### PR TITLE
add react-native doc link

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -84,7 +84,7 @@ export function ruleURI(ruleId) {
       return `https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/${ruleName}.md`
 
     case 'react-native':
-      return `https://github.com/Intellicode/eslint-plugin-react-native/tree/master/docs/rules/${ruleName}.md`
+      return `https://github.com/Intellicode/eslint-plugin-react-native/blob/master/docs/rules/${ruleName}.md`
 
     default:
       return 'https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation'

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -83,6 +83,9 @@ export function ruleURI(ruleId) {
     case 'react':
       return `https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/${ruleName}.md`
 
+    case 'react-native':
+      return `https://github.com/Intellicode/eslint-plugin-react-native/tree/master/docs/rules/${ruleName}.md`
+
     default:
       return 'https://github.com/AtomLinter/linter-eslint/wiki/Linking-to-Rule-Documentation'
   }


### PR DESCRIPTION
i could not manage to test this pr. either some magic happens here or i should first issue missing documentation on that. could you explain how to test or to implement a further doc link? the according wiki page ends abruptly.