### PR TITLE
Handle modified editor race conditions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -122,6 +122,15 @@ module.exports = {
           config: atom.config.get('linter-eslint'),
           filePath: filePath
         }).then(function (response) {
+          if (textEditor.getText() !== text) {
+            /*
+               The editor text has been modified since the lint was triggered,
+               as we can't be sure that the results will map properly back to
+               the new contents, simply return `null` to tell the
+               `provideLinter` consumer not to update the saved results.
+             */
+            return null;
+          }
           return response.map(function (_ref) {
             var message = _ref.message;
             var line = _ref.line;

--- a/src/main.js
+++ b/src/main.js
@@ -105,8 +105,17 @@ module.exports = {
           type: 'lint',
           config: atom.config.get('linter-eslint'),
           filePath
-        }).then((response) =>
-          response.map(({ message, line, severity, ruleId, column, fix }) => {
+        }).then((response) => {
+          if (textEditor.getText() !== text) {
+            /*
+               The editor text has been modified since the lint was triggered,
+               as we can't be sure that the results will map properly back to
+               the new contents, simply return `null` to tell the
+               `provideLinter` consumer not to update the saved results.
+             */
+            return null
+          }
+          return response.map(({ message, line, severity, ruleId, column, fix }) => {
             const textBuffer = textEditor.getBuffer()
             let linterFix = null
             if (fix) {
@@ -148,7 +157,7 @@ module.exports = {
             }
             return ret
           })
-        )
+        })
       }
     }
   }


### PR DESCRIPTION
When the TextEditor contents have been modified since the initial lint() was triggered, simply return `null` instead of trying to parse the results as the current text is no longer valid for positioning markers at.

Note that returning `null` makes Linter ignore the `lint(0` results, leaving the current messages untouched. Atom itself will have handled keeping old markers aligned with the text (if possible).

The worst case for the changes this PR introduces is that it might introduce a slightly longer delay between when a change is made in the document and lint results updating as any lint that has the text modified underneath it will simply stop processing.

There is _technically_ still a slight chance that a race condition could happen between the check introduced here and finishing processing the messages, but as the longest I have ever seen this take is 4ms I doubt that will be as major of an issue as this is currently.