### PR TITLE
Add ESLint to the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "devDependencies": {
     "babel-preset-steelbrain": "^4.0.2",
+    "eslint": "^3.6.0",
     "eslint-config-airbnb-base": "^8.0.0",
     "eslint-plugin-import": "^1.16.0",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
As ESLint is not only a dependency of this project, but also used for developing it, it should have been listed in here from the start. Brought to the forefront by https://github.com/atom/ci/pull/60 as we discovered that linting wasn't actually running on the CI builds.