### PR TITLE
Improve Atom startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "atom": ">=1.10.0 <2.0.0"
   },
+  "activationHooks": ["language-javascript:grammar-used"],
   "configSchema": {
     "lintHtmlFiles": {
       "title": "Lint HTML Files",

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -40,14 +40,22 @@ describe('The eslint provider for Linter', () => {
     atom.config.set('linter-eslint.disableFSCache', false)
     atom.config.set('linter-eslint.disableEslintIgnore', true)
 
+    // This whole beforeEach function is inspired by:
+    // https://github.com/AtomLinter/linter-jscs/pull/295/files
+    //
+    // See also:
+    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    const activationPromise =
+      atom.packages.activatePackage('linter-eslint')
+
     waitsForPromise(() =>
-      Promise.all([
-        atom.packages.activatePackage('language-javascript'),
-        atom.packages.activatePackage('linter-eslint'),
-      ]).then(() =>
-        atom.workspace.open(goodPath)
-      )
-    )
+      atom.packages.activatePackage('language-javascript'))
+
+    waitsForPromise(() =>
+      atom.workspace.open(goodPath))
+
+    atom.packages.triggerDeferredActivationHooks()
+    waitsForPromise(() => activationPromise)
   })
 
   describe('checks bad.js and', () => {

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -40,19 +40,15 @@ describe('The eslint provider for Linter', () => {
     atom.config.set('linter-eslint.disableFSCache', false)
     atom.config.set('linter-eslint.disableEslintIgnore', true)
 
-    // This whole beforeEach function is inspired by:
-    // https://github.com/AtomLinter/linter-jscs/pull/295/files
-    //
-    // See also:
-    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    // Info about this beforeEach() implementation:
+    // https://github.com/AtomLinter/Meta/issues/15
     const activationPromise =
       atom.packages.activatePackage('linter-eslint')
 
     waitsForPromise(() =>
-      atom.packages.activatePackage('language-javascript'))
-
-    waitsForPromise(() =>
-      atom.workspace.open(goodPath))
+      atom.packages.activatePackage('language-javascript').then(() =>
+        atom.workspace.open(goodPath))
+    )
 
     atom.packages.triggerDeferredActivationHooks()
     waitsForPromise(() => activationPromise)


### PR DESCRIPTION
Before this change, activation was done on Atom startup, whether or not
you actually had any Javascript files open.

With this change in place, we postpone activation until the Atom
Javascript grammar's first use.

This improves startup time of my Atom by about 180ms, thus fixing one of
the top startup time offenders according to TimeCop.

For some frame of reference, I have 87 packages installed, and Timecop
lists all packages with startup times above 5ms.