### PR TITLE
Determine fix results based on exit code

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,9 @@ module.exports = {
             config: atom.config.get('linter-eslint'),
             filePath,
             projectPath
-          }).catch(response => atom.notifications.addWarning(response));
+          }).catch(err => {
+            atom.notifications.addWarning(err.message);
+          });
         }
       });
     }));
@@ -87,7 +89,9 @@ module.exports = {
           config: atom.config.get('linter-eslint'),
           filePath,
           projectPath
-        }).then(response => atom.notifications.addSuccess(response)).catch(response => atom.notifications.addWarning(response));
+        }).then(response => atom.notifications.addSuccess(response)).catch(err => {
+          atom.notifications.addWarning(err.message);
+        });
       }
     }));
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,13 +1,21 @@
 'use strict';
 'use babel';
 
-// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
 
 var _atom = require('atom');
 
 var _helpers = require('./helpers');
 
+var _workerHelpers = require('./worker-helpers');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+
 
 // Configuration
 const scopes = [];
@@ -45,6 +53,11 @@ module.exports = {
         if (scopes.indexOf(editor.getGrammar().scopeName) !== -1 && atom.config.get('linter-eslint.fixOnSave')) {
           const filePath = editor.getPath();
           const projectPath = atom.project.relativizePath(filePath)[0];
+
+          // Do not try to fix if linting should be disabled
+          const fileDir = _path2.default.dirname(filePath);
+          const configPath = (0, _workerHelpers.getConfigPath)(fileDir);
+          if (configPath === null && atom.config.get('linter-eslint.disableWhenNoEslintConfig')) return;
 
           this.worker.request('job', {
             type: 'fix',

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,6 +21,7 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
 const scopes = [];
 let showRule;
 let ignoredRulesWhenModified;
+let disableWhenNoEslintConfig;
 
 module.exports = {
   activate() {
@@ -57,7 +58,7 @@ module.exports = {
           // Do not try to fix if linting should be disabled
           const fileDir = _path2.default.dirname(filePath);
           const configPath = (0, _workerHelpers.getConfigPath)(fileDir);
-          if (configPath === null && atom.config.get('linter-eslint.disableWhenNoEslintConfig')) return;
+          if (configPath === null && disableWhenNoEslintConfig) return;
 
           this.worker.request('job', {
             type: 'fix',
@@ -110,6 +111,10 @@ module.exports = {
 
     this.subscriptions.add(atom.config.observe('linter-eslint.showRuleIdInMessage', value => {
       showRule = value;
+    }));
+
+    this.subscriptions.add(atom.config.observe('linter-eslint.disableWhenNoEslintConfig', value => {
+      disableWhenNoEslintConfig = value;
     }));
 
     this.subscriptions.add(atom.config.observe('linter-eslint.rulesToSilenceWhileTyping', ids => {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -40,12 +40,11 @@ function lintJob(argv, contents, eslint, configPath, config) {
 }
 
 function fixJob(argv, eslint) {
-  try {
-    eslint.execute(argv);
-    return 'Linter-ESLint: Fix Complete';
-  } catch (err) {
-    throw new Error('Linter-ESLint: Fix Attempt Completed, Linting Errors Remain');
+  const exit = eslint.execute(argv);
+  if (exit === 0) {
+    return 'Linter-ESLint: Fix complete.';
   }
+  return 'Linter-ESLint: Fix attempt complete, but linting errors remain.';
 }
 
 (0, _processCommunication.create)().onRequest('job', (_ref, job) => {

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -194,7 +194,7 @@ describe('The eslint provider for Linter', () => {
         return fix(textEditor)
           .then((messagesAfterSave) => {
             // Linter reports a successful fix
-            expect(messagesAfterSave).toBe('Linter-ESLint: Fix Complete')
+            expect(messagesAfterSave).toBe('Linter-ESLint: Fix complete.')
           })
       }
       // Create a subscription to watch when the editor changes (from the fix)

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import { getConfigPath } from './worker-helpers'
 const scopes = []
 let showRule
 let ignoredRulesWhenModified
+let disableWhenNoEslintConfig
 
 module.exports = {
   activate() {
@@ -53,7 +54,7 @@ module.exports = {
           // Do not try to fix if linting should be disabled
           const fileDir = Path.dirname(filePath)
           const configPath = getConfigPath(fileDir)
-          if (configPath === null && atom.config.get('linter-eslint.disableWhenNoEslintConfig')) return
+          if (configPath === null && disableWhenNoEslintConfig) return
 
           this.worker.request('job', {
             type: 'fix',
@@ -103,6 +104,12 @@ module.exports = {
     this.subscriptions.add(
       atom.config.observe('linter-eslint.showRuleIdInMessage', (value) => {
         showRule = value
+      })
+    )
+
+    this.subscriptions.add(
+      atom.config.observe('linter-eslint.disableWhenNoEslintConfig', (value) => {
+        disableWhenNoEslintConfig = value
       })
     )
 

--- a/src/main.js
+++ b/src/main.js
@@ -53,9 +53,9 @@ module.exports = {
             config: atom.config.get('linter-eslint'),
             filePath,
             projectPath
-          }).catch(response =>
-            atom.notifications.addWarning(response)
-          )
+          }).catch((err) => {
+            atom.notifications.addWarning(err.message)
+          })
         }
       })
     }))
@@ -87,9 +87,9 @@ module.exports = {
           projectPath
         }).then(response =>
           atom.notifications.addSuccess(response)
-        ).catch(response =>
-          atom.notifications.addWarning(response)
-        )
+        ).catch((err) => {
+          atom.notifications.addWarning(err.message)
+        })
       }
     }))
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 'use babel'
 
+import Path from 'path'
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable, } from 'atom'
 
@@ -7,6 +8,7 @@ import {
   spawnWorker, showError, idsToIgnoredRules, processESLintMessages,
   generateDebugString
 } from './helpers'
+import { getConfigPath } from './worker-helpers'
 
 // Configuration
 const scopes = []
@@ -47,6 +49,11 @@ module.exports = {
             atom.config.get('linter-eslint.fixOnSave')) {
           const filePath = editor.getPath()
           const projectPath = atom.project.relativizePath(filePath)[0]
+
+          // Do not try to fix if linting should be disabled
+          const fileDir = Path.dirname(filePath)
+          const configPath = getConfigPath(fileDir)
+          if (configPath === null && atom.config.get('linter-eslint.disableWhenNoEslintConfig')) return
 
           this.worker.request('job', {
             type: 'fix',

--- a/src/worker.js
+++ b/src/worker.js
@@ -33,12 +33,11 @@ function lintJob(argv, contents, eslint, configPath, config) {
 }
 
 function fixJob(argv, eslint) {
-  try {
-    eslint.execute(argv)
-    return 'Linter-ESLint: Fix Complete'
-  } catch (err) {
-    throw new Error('Linter-ESLint: Fix Attempt Completed, Linting Errors Remain')
+  const exit = eslint.execute(argv)
+  if (exit === 0) {
+    return 'Linter-ESLint: Fix complete.'
   }
+  return 'Linter-ESLint: Fix attempt complete, but linting errors remain.'
 }
 
 create().onRequest('job', ({ contents, type, config, filePath, projectPath, rules }, job) => {


### PR DESCRIPTION
Fixes #511 

## Description

This adjusts the response of running `Linter eslint: fix` or fixing automatically on save, so that unexpected runtime errors are correctly printed in a notification.

This PR also no longer treats an incomplete `fix` as requiring a warning.  A success message is given whether the fix is total or partial, with only the wording being altered to reflect the result.  As I mention in the commit message details, I believe `eslint.execute` used to throw when autofix did not fix all of the errors in a file.  It no longer does, so we need to rely on the exit code instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/777)
<!-- Reviewable:end -->
