### PR TITLE
Allow rules to be excluded from fixes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -23,6 +23,7 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
 const scopes = [];
 let showRule;
 let ignoredRulesWhenModified;
+let ignoredRulesWhenFixing;
 let disableWhenNoEslintConfig;
 
 module.exports = {
@@ -63,9 +64,15 @@ module.exports = {
           const noProjectConfig = configPath === null || (0, _isConfigAtHomeRoot.isConfigAtHomeRoot)(configPath);
           if (noProjectConfig && disableWhenNoEslintConfig) return;
 
+          let rules = {};
+          if (Object.keys(ignoredRulesWhenFixing).length > 0) {
+            rules = ignoredRulesWhenFixing;
+          }
+
           this.worker.request('job', {
             type: 'fix',
             config: atom.config.get('linter-eslint'),
+            rules,
             filePath,
             projectPath
           }).catch(err => {
@@ -101,9 +108,15 @@ module.exports = {
           return;
         }
 
+        let rules = {};
+        if (textEditor.isModified() && Object.keys(ignoredRulesWhenFixing).length > 0) {
+          rules = ignoredRulesWhenFixing;
+        }
+
         this.worker.request('job', {
           type: 'fix',
           config: atom.config.get('linter-eslint'),
+          rules,
           filePath,
           projectPath
         }).then(response => atom.notifications.addSuccess(response)).catch(err => {
@@ -122,6 +135,10 @@ module.exports = {
 
     this.subscriptions.add(atom.config.observe('linter-eslint.rulesToSilenceWhileTyping', ids => {
       ignoredRulesWhenModified = (0, _helpers.idsToIgnoredRules)(ids);
+    }));
+
+    this.subscriptions.add(atom.config.observe('linter-eslint.rulesToDisableWhileFixing', ids => {
+      ignoredRulesWhenFixing = (0, _helpers.idsToIgnoredRules)(ids);
     }));
 
     const initializeWorker = () => {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,15 @@
       "items": {
         "type": "string"
       }
+    },
+    "rulesToDisableWhileFixing": {
+      "title": "Disable specific rules from fixes",
+      "description": "Prevent rules from being auto-fixed by ESLint. Applies to fixes made during saves as well as when running the `Linter Eslint: Fix File` command.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
     }
   },
   "scripts": {

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -175,21 +175,24 @@ describe('The eslint provider for Linter', () => {
     let editor
     let doneCheckingFixes
     let tempFixtureDir
-    let tempFixturePath
-    let tempConfigPath
 
     beforeEach(() => {
-      waitsForPromise(() => {
-        tempFixtureDir = fs.mkdtempSync(tmpdir() + path.sep)
-        tempFixturePath = path.join(tempFixtureDir, 'fixed.js')
-        tempConfigPath = path.join(tempFixtureDir, '.eslintrc.yaml')
-        fs.createReadStream(configPath).pipe(fs.createWriteStream(tempConfigPath))
+      waitsForPromise(() =>
+        copyFileToTempDir(fixPath)
+          .then(({ openEditor, tempDir }) => {
+            editor = openEditor
+            tempFixtureDir = tempDir
 
-        return atom.workspace.open(fixPath).then((openEditor) => {
-          openEditor.saveAs(tempFixturePath)
-          editor = openEditor
-        })
-      })
+            return new Promise((resolve) => {
+              const configWritePath = path.join(tempFixtureDir, path.basename(configPath))
+              const wr = fs.createWriteStream(configWritePath)
+              wr.on('close', () => {
+                resolve()
+              })
+              fs.createReadStream(configPath).pipe(wr)
+            })
+          })
+      )
     })
 
     afterEach(() => {


### PR DESCRIPTION
Closes #791 

## Description

This adds an option, "Disable specific rules from fixes" which allows users to specify a list of rules which should _not_ be auto-fixed by ESLint.  The option is _very_ similar to the already-existing `rulesToSilenceWhileTyping` option, and uses the same strategy of setting `--rule` to disable the specified rules.  

## Notes

In the interest of simplicity and avoiding surprises, this option applies to both fixes made during saves, as well as manual fixes run from the command palette.  

The spec is largely duplicated from the existing spec for fix jobs, but it didn't make sense to me to try to abstract it out into another function.  That would just add some indirection for very little benefit, in my opinion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/795)
<!-- Reviewable:end -->
