### PR TITLE
:bug: Exclude .babelrc from APM releases (fixes #796)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # (binary is a macro for -text -diff)
 *.png binary
+
+# Exclude build-time .babelrc config from APM pkg (#796)
+.babelrc export-ignore


### PR DESCRIPTION
Background
----------

It appears that if any file recursively `require`d by the linter-eslint worker includes `babel/register`, then all babel configs through all parent directories of that file are processed.

Here is where `babel/register` inits `OptionManager`: https://github.com/babel/babel/blob/master/packages/babel-register/src/node.js#L51

And here is where `OptionManager` iterates parent dirs: https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/file/options/build-config-chain.js#L60

In #796, this happens specifically when `eslint-import-resolver-webpack` `require`s a webpack config that in turn `require`s `babel/register`.  `register` inits `OptionManager`, which in turn finds and processes all babel configs in parent dirs, and chokes when it cannot find the referenced plugins/presets.

Here is where `eslint-import-resolver-webpack` `require`s the webpack config (vanilla require): https://github.com/benmosher/eslint-plugin-import/blob/master/resolvers/webpack/index.js#L68

Solution
--------

Since the `.babelrc` is going to get processed if it is present in the APM package dir, either

- Any plugins or presets it uses must be production deps, OR
- The `.babelrc` file must not be in the isntalled APM package

This PR does the latter since `.babelrc` seems to be only a build-time config, and not needed to run the plugin.  (Locally I have confirmed that simplying deleting the `.babelrc` file from the APM package dir fixes #796)

Changes
-------

- Added git attribute to export-ignore build-time babelrc config


Related
--------

APM/export-ignore: https://github.com/atom/apm/issues/498#issuecomment-260159766

Closes #796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-eslint/809)
<!-- Reviewable:end -->
