### PR TITLE
Use cursor scope when checking fixOnSave scopes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,8 +54,7 @@ module.exports = {
 
     this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
       editor.onDidSave(() => {
-        const editorScopes = editor.getLastCursor().getScopeDescriptor().scopes;
-        const validScope = editorScopes.some(scope => scopes.includes(scope));
+        const validScope = editor.getCursors().some(cursor => cursor.getScopeDescriptor().getScopesArray().some(scope => scopes.includes(scope)));
         if (validScope && atom.config.get('linter-eslint.fixOnSave')) {
           const filePath = editor.getPath();
           const projectPath = atom.project.relativizePath(filePath)[0];

--- a/lib/main.js
+++ b/lib/main.js
@@ -54,7 +54,9 @@ module.exports = {
 
     this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
       editor.onDidSave(() => {
-        if (scopes.indexOf(editor.getGrammar().scopeName) !== -1 && atom.config.get('linter-eslint.fixOnSave')) {
+        const editorScopes = editor.getLastCursor().getScopeDescriptor().scopes;
+        const validScope = editorScopes.some(scope => scopes.includes(scope));
+        if (validScope && atom.config.get('linter-eslint.fixOnSave')) {
           const filePath = editor.getPath();
           const projectPath = atom.project.relativizePath(filePath)[0];
 

--- a/src/main.js
+++ b/src/main.js
@@ -48,8 +48,9 @@ module.exports = {
 
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
       editor.onDidSave(() => {
-        const editorScopes = editor.getLastCursor().getScopeDescriptor().scopes
-        const validScope = editorScopes.some(scope => scopes.includes(scope))
+        const validScope = editor.getCursors().some(cursor =>
+          cursor.getScopeDescriptor().getScopesArray().some(scope =>
+            scopes.includes(scope)))
         if (validScope && atom.config.get('linter-eslint.fixOnSave')) {
           const filePath = editor.getPath()
           const projectPath = atom.project.relativizePath(filePath)[0]

--- a/src/main.js
+++ b/src/main.js
@@ -48,8 +48,9 @@ module.exports = {
 
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
       editor.onDidSave(() => {
-        if (scopes.indexOf(editor.getGrammar().scopeName) !== -1 &&
-            atom.config.get('linter-eslint.fixOnSave')) {
+        const editorScopes = editor.getLastCursor().getScopeDescriptor().scopes
+        const validScope = editorScopes.some(scope => scopes.includes(scope))
+        if (validScope && atom.config.get('linter-eslint.fixOnSave')) {
           const filePath = editor.getPath()
           const projectPath = atom.project.relativizePath(filePath)[0]
 


### PR DESCRIPTION
When the fixOnSave callback is ran previously we were using the file level "master scope", this fails though when the user has enabled HTML embedded JS linting. Use the cursors of the provided editor to check the valid scopes.

Fixes #794.