### PR TITLE
Check for undefined package path

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,8 +11,14 @@ let getDebugInfo = exports.getDebugInfo = (() => {
     const textEditor = atom.workspace.getActiveTextEditor();
     const filePath = textEditor.getPath();
     const packagePath = atom.packages.resolvePackagePath('linter-eslint');
-    // eslint-disable-next-line import/no-dynamic-require
-    const linterEslintMeta = require((0, _path.join)(packagePath, 'package.json'));
+    let linterEslintMeta;
+    if (packagePath === undefined) {
+      // Apparently for some users the package path fails to resolve
+      linterEslintMeta = { version: 'unknown!' };
+    } else {
+      // eslint-disable-next-line import/no-dynamic-require
+      linterEslintMeta = require((0, _path.join)(packagePath, 'package.json'));
+    }
     const config = atom.config.get('linter-eslint');
     const hoursSinceRestart = Math.round(process.uptime() / 3600 * 10) / 10;
     let returnVal;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -72,8 +72,14 @@ export async function getDebugInfo(worker) {
   const textEditor = atom.workspace.getActiveTextEditor()
   const filePath = textEditor.getPath()
   const packagePath = atom.packages.resolvePackagePath('linter-eslint')
-  // eslint-disable-next-line import/no-dynamic-require
-  const linterEslintMeta = require(join(packagePath, 'package.json'))
+  let linterEslintMeta
+  if (packagePath === undefined) {
+    // Apparently for some users the package path fails to resolve
+    linterEslintMeta = { version: 'unknown!' }
+  } else {
+    // eslint-disable-next-line import/no-dynamic-require
+    linterEslintMeta = require(join(packagePath, 'package.json'))
+  }
   const config = atom.config.get('linter-eslint')
   const hoursSinceRestart = Math.round((process.uptime() / 3600) * 10) / 10
   let returnVal


### PR DESCRIPTION
Apparently for some users the `atom.packages.resolvePackagePath('linter-eslint')` command can fail to return the package path. When this happens create a fake Object setting the version to `unknown!`.

Fixes #784.