### PR TITLE
Temporarily disable a spec

### DIFF
--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -243,7 +243,7 @@ describe('The eslint provider for Linter', () => {
       )
     })
 
-    it('should not fix linting errors for rules that are disabled with rulesToDisableWhileFixing', () => {
+    xit('should not fix linting errors for rules that are disabled with rulesToDisableWhileFixing', () => {
       atom.config.set('linter-eslint.rulesToDisableWhileFixing', ['semi'])
 
       function firstLint(textEditor) {


### PR DESCRIPTION
This particular spec has been intermittently, but quite often, failing on CircleCI. Disable it till the issue can be tracked down.

Closes #800.
Closes #803.
Closes #804.