### PR TITLE
Remove custom styling

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -135,8 +135,8 @@ let processESLintMessages = exports.processESLintMessages = (() => {
 
           if (showRule) {
             const elName = ruleId ? 'a' : 'span';
-            const href = ruleId ? ` href=${(0, _eslintRuleDocumentation2.default)(ruleId).url}` : '';
-            ret.html = `<${elName}${href} class="badge badge-flexible eslint">` + `${ruleId || 'Fatal'}</${elName}> ${(0, _escapeHtml2.default)(message)}`;
+            const href = ruleId ? ` href="${(0, _eslintRuleDocumentation2.default)(ruleId).url}"` : '';
+            ret.html = `${(0, _escapeHtml2.default)(message)} (<${elName}${href}>${ruleId || 'Fatal'}</${elName}>)`;
           } else {
             ret.text = message;
           }

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -86,9 +86,8 @@ describe('The eslint provider for Linter', () => {
     it('verifies that message', () => {
       waitsForPromise(() =>
         lint(editor).then((messages) => {
-          const expected = '<a href=http://eslint.org/docs/rules/no-undef ' +
-            'class="badge badge-flexible eslint">no-undef</a> ' +
-            '&#39;foo&#39; is not defined.'
+          const expected = '&#39;foo&#39; is not defined. ' +
+            '(<a href="http://eslint.org/docs/rules/no-undef">no-undef</a>)'
           expect(messages[0].type).toBe('Error')
           expect(messages[0].text).not.toBeDefined()
           expect(messages[0].html).toBe(expected)
@@ -142,10 +141,9 @@ describe('The eslint provider for Linter', () => {
       waitsForPromise(() =>
         atom.workspace.open(badImportPath).then(editor =>
           lint(editor).then((messages) => {
-            const expected = '<a href=' +
-              'https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md ' +
-              'class="badge badge-flexible eslint">import/no-unresolved</a> ' +
-              'Unable to resolve path to module &#39;../nonexistent&#39;.'
+            const expected = 'Unable to resolve path to module &#39;../nonexistent&#39;. ' +
+              '(<a href="https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md">' +
+              'import/no-unresolved</a>)'
 
             expect(messages.length).toBeGreaterThan(0)
             expect(messages[0].type).toBe('Error')
@@ -271,7 +269,7 @@ describe('The eslint provider for Linter', () => {
             if (messagesAfterFixing) {
               // There is still one linting error, `semi` which was disabled during fixing
               expect(messagesAfterFixing.length).toBe(1)
-              expect(messagesAfterFixing[0].html).toBe('<a href=http://eslint.org/docs/rules/semi class="badge badge-flexible eslint">semi</a> Extra semicolon.')
+              expect(messagesAfterFixing[0].html).toBe('Extra semicolon. (<a href="http://eslint.org/docs/rules/semi">semi</a>)')
               doneCheckingFixes = true
             }
           })
@@ -289,9 +287,8 @@ describe('The eslint provider for Linter', () => {
   })
 
   describe('Ignores specified rules when editing', () => {
-    const expected = '<a href=http://eslint.org/docs/rules/no-trailing-spaces ' +
-      'class="badge badge-flexible eslint">no-trailing-spaces</a> ' +
-      'Trailing spaces not allowed.'
+    const expected = 'Trailing spaces not allowed. ' +
+      '(<a href="http://eslint.org/docs/rules/no-trailing-spaces">no-trailing-spaces</a>)'
     it('does nothing on saved files', () => {
       atom.config.set('linter-eslint.rulesToSilenceWhileTyping', ['no-trailing-spaces'])
       waitsForPromise(() =>
@@ -414,9 +411,8 @@ describe('The eslint provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(endRangePath).then(editor =>
         lint(editor).then((messages) => {
-          const expected = '<a href=http://eslint.org/docs/rules/no-unreachable ' +
-            'class="badge badge-flexible eslint">no-unreachable</a> ' +
-            'Unreachable code.'
+          const expected = 'Unreachable code. ' +
+            '(<a href="http://eslint.org/docs/rules/no-unreachable">no-unreachable</a>)'
           expect(messages[0].type).toBe('Error')
           expect(messages[0].text).not.toBeDefined()
           expect(messages[0].html).toBe(expected)
@@ -454,8 +450,8 @@ describe('The eslint provider for Linter', () => {
         .then((messages) => {
           // Older versions of ESLint will report an error
           // (or if current user running tests has a config in their home directory)
-          const expectedHtml = '<a href=http://eslint.org/docs/rules/no-undef ' +
-            'class="badge badge-flexible eslint">no-undef</a> &#39;foo&#39; is not defined.'
+          const expectedHtml = '&#39;foo&#39; is not defined. ' +
+            '(<a href="http://eslint.org/docs/rules/no-undef">no-undef</a>)'
           expect(messages.length).toBe(1)
           expect(messages[0].html).toBe(expectedHtml)
           gotLintingErrors = true

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -236,9 +236,8 @@ export async function processESLintMessages(response, textEditor, showRule, work
 
       if (showRule) {
         const elName = ruleId ? 'a' : 'span'
-        const href = ruleId ? ` href=${ruleURI(ruleId).url}` : ''
-        ret.html = `<${elName}${href} class="badge badge-flexible eslint">` +
-          `${ruleId || 'Fatal'}</${elName}> ${escapeHTML(message)}`
+        const href = ruleId ? ` href="${ruleURI(ruleId).url}"` : ''
+        ret.html = `${escapeHTML(message)} (<${elName}${href}>${ruleId || 'Fatal'}</${elName}>)`
       } else {
         ret.text = message
       }

--- a/styles/atom-text-editor.less
+++ b/styles/atom-text-editor.less
@@ -1,5 +1,0 @@
-@import "ui-variables";
-
-#linter-inline a.eslint {
-  color: @text-color-selected;
-}


### PR DESCRIPTION
The forced styling being done before was breaking on several themes, to the point where some were unreadable. This removes the badge styling and instead lets the theme handle the URL as a simple link. Rule name is moved to the end of the message, similar to ESLint's CLI output.

For example in my current theme this is what it looks like before this PR:
![image](https://cloud.githubusercontent.com/assets/427137/22848698/15d86e2a-efab-11e6-8bad-f657b4298ce2.png)

And after:
![image](https://cloud.githubusercontent.com/assets/427137/22848705/23663c20-efab-11e6-893e-16e328473c0b.png)


Fixes #482.