### PR TITLE
Log the file scope in debug command

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,7 +59,7 @@ let getDebugInfo = exports.getDebugInfo = (() => {
 let generateDebugString = exports.generateDebugString = (() => {
   var _ref2 = _asyncToGenerator(function* (worker) {
     const debug = yield getDebugInfo(worker);
-    const details = [`Atom version: ${debug.atomVersion}`, `linter-eslint version: ${debug.linterEslintVersion}`, `ESLint version: ${debug.eslintVersion}`, `Hours since last Atom restart: ${debug.hoursSinceRestart}`, `Platform: ${debug.platform}`, `Using ${debug.eslintType} ESLint from ${debug.eslintPath}`, `linter-eslint configuration: ${JSON.stringify(debug.linterEslintConfig, null, 2)}`];
+    const details = [`Atom version: ${debug.atomVersion}`, `linter-eslint version: ${debug.linterEslintVersion}`, `ESLint version: ${debug.eslintVersion}`, `Hours since last Atom restart: ${debug.hoursSinceRestart}`, `Platform: ${debug.platform}`, `Using ${debug.eslintType} ESLint from: ${debug.eslintPath}`, `linter-eslint configuration: ${JSON.stringify(debug.linterEslintConfig, null, 2)}`];
     return details.join('\n');
   });
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,11 +10,14 @@ let getDebugInfo = exports.getDebugInfo = (() => {
   var _ref = _asyncToGenerator(function* (worker) {
     const textEditor = atom.workspace.getActiveTextEditor();
     let filePath;
+    let editorScopes;
     if (atom.workspace.isTextEditor(textEditor)) {
       filePath = textEditor.getPath();
+      editorScopes = textEditor.getLastCursor().getScopeDescriptor().getScopesArray();
     } else {
       // Somehow this can be called with no active TextEditor, impossible I know...
       filePath = 'unknown';
+      editorScopes = ['unknown'];
     }
     const packagePath = atom.packages.resolvePackagePath('linter-eslint');
     let linterEslintMeta;
@@ -43,7 +46,8 @@ let getDebugInfo = exports.getDebugInfo = (() => {
         hoursSinceRestart,
         platform: process.platform,
         eslintType: response.type,
-        eslintPath: response.path
+        eslintPath: response.path,
+        editorScopes
       };
     } catch (error) {
       atom.notifications.addError(`${error}`);
@@ -59,7 +63,7 @@ let getDebugInfo = exports.getDebugInfo = (() => {
 let generateDebugString = exports.generateDebugString = (() => {
   var _ref2 = _asyncToGenerator(function* (worker) {
     const debug = yield getDebugInfo(worker);
-    const details = [`Atom version: ${debug.atomVersion}`, `linter-eslint version: ${debug.linterEslintVersion}`, `ESLint version: ${debug.eslintVersion}`, `Hours since last Atom restart: ${debug.hoursSinceRestart}`, `Platform: ${debug.platform}`, `Using ${debug.eslintType} ESLint from: ${debug.eslintPath}`, `linter-eslint configuration: ${JSON.stringify(debug.linterEslintConfig, null, 2)}`];
+    const details = [`Atom version: ${debug.atomVersion}`, `linter-eslint version: ${debug.linterEslintVersion}`, `ESLint version: ${debug.eslintVersion}`, `Hours since last Atom restart: ${debug.hoursSinceRestart}`, `Platform: ${debug.platform}`, `Using ${debug.eslintType} ESLint from: ${debug.eslintPath}`, `Current file's scopes: ${JSON.stringify(debug.editorScopes, null, 2)}`, `linter-eslint configuration: ${JSON.stringify(debug.linterEslintConfig, null, 2)}`];
     return details.join('\n');
   });
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,7 +9,13 @@ exports.processESLintMessages = exports.generateDebugString = exports.getDebugIn
 let getDebugInfo = exports.getDebugInfo = (() => {
   var _ref = _asyncToGenerator(function* (worker) {
     const textEditor = atom.workspace.getActiveTextEditor();
-    const filePath = textEditor.getPath();
+    let filePath;
+    if (atom.workspace.isTextEditor(textEditor)) {
+      filePath = textEditor.getPath();
+    } else {
+      // Somehow this can be called with no active TextEditor, impossible I know...
+      filePath = 'unknown';
+    }
     const packagePath = atom.packages.resolvePackagePath('linter-eslint');
     let linterEslintMeta;
     if (packagePath === undefined) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -70,7 +70,13 @@ function validatePoint(textEditor, line, col) {
 
 export async function getDebugInfo(worker) {
   const textEditor = atom.workspace.getActiveTextEditor()
-  const filePath = textEditor.getPath()
+  let filePath
+  if (atom.workspace.isTextEditor(textEditor)) {
+    filePath = textEditor.getPath()
+  } else {
+    // Somehow this can be called with no active TextEditor, impossible I know...
+    filePath = 'unknown'
+  }
   const packagePath = atom.packages.resolvePackagePath('linter-eslint')
   let linterEslintMeta
   if (packagePath === undefined) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -71,11 +71,14 @@ function validatePoint(textEditor, line, col) {
 export async function getDebugInfo(worker) {
   const textEditor = atom.workspace.getActiveTextEditor()
   let filePath
+  let editorScopes
   if (atom.workspace.isTextEditor(textEditor)) {
     filePath = textEditor.getPath()
+    editorScopes = textEditor.getLastCursor().getScopeDescriptor().getScopesArray()
   } else {
     // Somehow this can be called with no active TextEditor, impossible I know...
     filePath = 'unknown'
+    editorScopes = ['unknown']
   }
   const packagePath = atom.packages.resolvePackagePath('linter-eslint')
   let linterEslintMeta
@@ -105,6 +108,7 @@ export async function getDebugInfo(worker) {
       platform: process.platform,
       eslintType: response.type,
       eslintPath: response.path,
+      editorScopes,
     }
   } catch (error) {
     atom.notifications.addError(`${error}`)
@@ -121,6 +125,7 @@ export async function generateDebugString(worker) {
     `Hours since last Atom restart: ${debug.hoursSinceRestart}`,
     `Platform: ${debug.platform}`,
     `Using ${debug.eslintType} ESLint from: ${debug.eslintPath}`,
+    `Current file's scopes: ${JSON.stringify(debug.editorScopes, null, 2)}`,
     `linter-eslint configuration: ${JSON.stringify(debug.linterEslintConfig, null, 2)}`
   ]
   return details.join('\n')

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -120,7 +120,7 @@ export async function generateDebugString(worker) {
     `ESLint version: ${debug.eslintVersion}`,
     `Hours since last Atom restart: ${debug.hoursSinceRestart}`,
     `Platform: ${debug.platform}`,
-    `Using ${debug.eslintType} ESLint from ${debug.eslintPath}`,
+    `Using ${debug.eslintType} ESLint from: ${debug.eslintPath}`,
     `linter-eslint configuration: ${JSON.stringify(debug.linterEslintConfig, null, 2)}`
   ]
   return details.join('\n')


### PR DESCRIPTION
Display the scopes of the last cursor in the current file in the debug command so they can be verified against the scopes allowed in the configuration of the package.

Also guards against an invalid `TextEditor` somehow getting returned from `atom.workspace.getActiveTextEditor()`.