### PR TITLE
restore cursor position after fix command

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -70,12 +70,15 @@ module.exports = {
             rules = ignoredRulesWhenFixing;
           }
 
+          const cursorPosition = editor.getCursorBufferPosition();
           this.worker.request('job', {
             type: 'fix',
             config: atom.config.get('linter-eslint'),
             rules,
             filePath,
             projectPath
+          }).then(() => {
+            editor.setCursorBufferPosition(cursorPosition);
           }).catch(err => {
             atom.notifications.addWarning(err.message);
           });
@@ -114,13 +117,16 @@ module.exports = {
           rules = ignoredRulesWhenFixing;
         }
 
+        const cursorPosition = textEditor.getCursorBufferPosition();
         this.worker.request('job', {
           type: 'fix',
           config: atom.config.get('linter-eslint'),
           rules,
           filePath,
           projectPath
-        }).then(response => atom.notifications.addSuccess(response)).catch(err => {
+        }).then(response => atom.notifications.addSuccess(response)).then(() => {
+          textEditor.setCursorBufferPosition(cursorPosition);
+        }).catch(err => {
           atom.notifications.addWarning(err.message);
         });
       }

--- a/src/main.js
+++ b/src/main.js
@@ -66,12 +66,15 @@ module.exports = {
             rules = ignoredRulesWhenFixing
           }
 
+          const cursorPosition = editor.getCursorBufferPosition()
           this.worker.request('job', {
             type: 'fix',
             config: atom.config.get('linter-eslint'),
             rules,
             filePath,
             projectPath
+          }).then(() => {
+            editor.setCursorBufferPosition(cursorPosition)
           }).catch((err) => {
             atom.notifications.addWarning(err.message)
           })
@@ -104,6 +107,7 @@ module.exports = {
           rules = ignoredRulesWhenFixing
         }
 
+        const cursorPosition = textEditor.getCursorBufferPosition()
         this.worker.request('job', {
           type: 'fix',
           config: atom.config.get('linter-eslint'),
@@ -112,7 +116,9 @@ module.exports = {
           projectPath
         }).then(response =>
           atom.notifications.addSuccess(response)
-        ).catch((err) => {
+        ).then(() => {
+          textEditor.setCursorBufferPosition(cursorPosition)
+        }).catch((err) => {
           atom.notifications.addWarning(err.message)
         })
       }

--- a/src/main.js
+++ b/src/main.js
@@ -66,6 +66,8 @@ module.exports = {
             rules = ignoredRulesWhenFixing
           }
 
+          // The fix replaces the file content and the cursor jumps automatically
+          // to the beginning of the file, so save current cursor position
           const cursorPosition = editor.getCursorBufferPosition()
           this.worker.request('job', {
             type: 'fix',
@@ -74,6 +76,7 @@ module.exports = {
             filePath,
             projectPath
           }).then(() => {
+            // set cursor to the position before fix job
             editor.setCursorBufferPosition(cursorPosition)
           }).catch((err) => {
             atom.notifications.addWarning(err.message)
@@ -107,6 +110,8 @@ module.exports = {
           rules = ignoredRulesWhenFixing
         }
 
+        // The fix replaces the file content and the cursor jumps automatically
+        // to the beginning of the file, so save current cursor position
         const cursorPosition = textEditor.getCursorBufferPosition()
         this.worker.request('job', {
           type: 'fix',
@@ -117,6 +122,7 @@ module.exports = {
         }).then(response =>
           atom.notifications.addSuccess(response)
         ).then(() => {
+          // set cursor to the position before fix job
           textEditor.setCursorBufferPosition(cursorPosition)
         }).catch((err) => {
           atom.notifications.addWarning(err.message)


### PR DESCRIPTION
The cursor at the moment jumps to the beginning of the file after the fix command. It infuriates me :)