### PR TITLE
Adding support for a comma separated list of advancedLocalNodeModules

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -70,6 +70,8 @@ module.exports = {
             rules = ignoredRulesWhenFixing;
           }
 
+          // The fix replaces the file content and the cursor jumps automatically
+          // to the beginning of the file, so save current cursor position
           const cursorPosition = editor.getCursorBufferPosition();
           this.worker.request('job', {
             type: 'fix',
@@ -78,6 +80,7 @@ module.exports = {
             filePath,
             projectPath
           }).then(() => {
+            // set cursor to the position before fix job
             editor.setCursorBufferPosition(cursorPosition);
           }).catch(err => {
             atom.notifications.addWarning(err.message);
@@ -117,6 +120,8 @@ module.exports = {
           rules = ignoredRulesWhenFixing;
         }
 
+        // The fix replaces the file content and the cursor jumps automatically
+        // to the beginning of the file, so save current cursor position
         const cursorPosition = textEditor.getCursorBufferPosition();
         this.worker.request('job', {
           type: 'fix',
@@ -125,6 +130,7 @@ module.exports = {
           filePath,
           projectPath
         }).then(response => atom.notifications.addSuccess(response)).then(() => {
+          // set cursor to the position before fix job
           textEditor.setCursorBufferPosition(cursorPosition);
         }).catch(err => {
           atom.notifications.addWarning(err.message);

--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -71,12 +71,17 @@ function findESLintDirectory(modulesDir, config, projectPath) {
   } else if (!config.advancedLocalNodeModules) {
     locationType = 'local project';
     eslintDir = _path2.default.join(modulesDir || '', 'eslint');
-  } else if (_path2.default.isAbsolute(config.advancedLocalNodeModules)) {
-    locationType = 'advanced specified';
-    eslintDir = _path2.default.join(config.advancedLocalNodeModules || '', 'eslint');
   } else {
-    locationType = 'advanced specified';
-    eslintDir = _path2.default.join(projectPath, config.advancedLocalNodeModules, 'eslint');
+    config.advancedLocalNodeModules.split(',').some(localNodeModulePath => {
+      if (_path2.default.isAbsolute(localNodeModulePath)) {
+        locationType = 'advanced specified';
+        eslintDir = _path2.default.join(localNodeModulePath || '', 'eslint');
+      } else {
+        locationType = 'advanced specified';
+        eslintDir = _path2.default.join(projectPath, localNodeModulePath, 'eslint');
+      }
+      return _fs2.default.existsSync(eslintDir);
+    });
   }
   try {
     if (_fs2.default.statSync(eslintDir).isDirectory()) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "advancedLocalNodeModules": {
       "title": "Path to the local node_modules folder",
-      "description": "Optionally specify the path to the local node_modules folder",
+      "description": "Optionally specify the path to the local node_modules folder (separate multiple paths with a comma)",
       "type": "string",
       "default": ""
     },

--- a/spec/worker-helpers-spec.js
+++ b/spec/worker-helpers-spec.js
@@ -76,6 +76,17 @@ describe('Worker Helpers', () => {
 
       expect(eslint).toBe('located')
     })
+    it('tries to find an indirect local eslint using comma separated absolute paths', () => {
+      const path1 = Path.join(
+        getFixturesPath('indirect-local-eslint'), 'testing-non-existing', 'eslint', 'node_modules')
+      const path2 = Path.join(
+        getFixturesPath('indirect-local-eslint'), 'testing', 'eslint', 'node_modules')
+      const eslint = Helpers.getESLintInstance('', {
+        useGlobalEslint: false,
+        advancedLocalNodeModules: [path1, path2].join(',')
+      })
+      expect(eslint).toBe('located')
+    })
     it('tries to find a local eslint', () => {
       const eslint = Helpers.getESLintInstance(getFixturesPath('local-eslint'), {})
       expect(eslint).toBe('located')

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -44,12 +44,17 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
   } else if (!config.advancedLocalNodeModules) {
     locationType = 'local project'
     eslintDir = Path.join(modulesDir || '', 'eslint')
-  } else if (Path.isAbsolute(config.advancedLocalNodeModules)) {
-    locationType = 'advanced specified'
-    eslintDir = Path.join(config.advancedLocalNodeModules || '', 'eslint')
   } else {
-    locationType = 'advanced specified'
-    eslintDir = Path.join(projectPath, config.advancedLocalNodeModules, 'eslint')
+    config.advancedLocalNodeModules.split(',').some((localNodeModulePath) => {
+      if (Path.isAbsolute(localNodeModulePath)) {
+        locationType = 'advanced specified'
+        eslintDir = Path.join(localNodeModulePath || '', 'eslint')
+      } else {
+        locationType = 'advanced specified'
+        eslintDir = Path.join(projectPath, localNodeModulePath, 'eslint')
+      }
+      return fs.existsSync(eslintDir)
+    })
   }
   try {
     if (fs.statSync(eslintDir).isDirectory()) {


### PR DESCRIPTION
Different projects may have eslint installed in different locations. This change allows a user to specify a list of node_modules paths to check for eslint.

i. e. "node_modules,react-scripts/node_modules" would first look for eslint in the local node_modules, if it did not find it there it would check for react-scripts/node_modules.