### PR TITLE
Reduce package activation time

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -55,7 +55,7 @@ let getDebugInfo = exports.getDebugInfo = (() => {
     return returnVal;
   });
 
-  return function getDebugInfo(_x3) {
+  return function getDebugInfo(_x2) {
     return _ref.apply(this, arguments);
   };
 })();
@@ -67,7 +67,7 @@ let generateDebugString = exports.generateDebugString = (() => {
     return details.join('\n');
   });
 
-  return function generateDebugString(_x4) {
+  return function generateDebugString(_x3) {
     return _ref2.apply(this, arguments);
   };
 })();
@@ -164,20 +164,19 @@ let processESLintMessages = exports.processESLintMessages = (() => {
         return ret;
       });
 
-      return function (_x19) {
+      return function (_x18) {
         return _ref6.apply(this, arguments);
       };
     })()));
   });
 
-  return function processESLintMessages(_x15, _x16, _x17, _x18) {
+  return function processESLintMessages(_x14, _x15, _x16, _x17) {
     return _ref4.apply(this, arguments);
   };
 })();
 
 exports.spawnWorker = spawnWorker;
 exports.showError = showError;
-exports.idsToIgnoredRules = idsToIgnoredRules;
 
 var _child_process = require('child_process');
 
@@ -205,8 +204,6 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
 
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 
-
-const RULE_OFF_SEVERITY = 0;
 
 function spawnWorker() {
   const env = Object.create(process.env);
@@ -251,15 +248,6 @@ function showError(givenMessage) {
   });
 }
 
-function idsToIgnoredRules() {
-  let ruleIds = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-
-  return ruleIds.reduce((ids, id) => {
-    ids[id] = RULE_OFF_SEVERITY;
-    return ids;
-  }, {});
-}
-
 function validatePoint(textEditor, line, col) {
   const buffer = textEditor.getBuffer();
   // Clip the given point to a valid one, and check if it equals the original
@@ -300,7 +288,7 @@ const generateInvalidTrace = (() => {
     };
   });
 
-  return function generateInvalidTrace(_x5, _x6, _x7, _x8, _x9, _x10, _x11, _x12, _x13, _x14) {
+  return function generateInvalidTrace(_x4, _x5, _x6, _x7, _x8, _x9, _x10, _x11, _x12, _x13) {
     return _ref3.apply(this, arguments);
   };
 })();

--- a/lib/is-config-at-home-root.js
+++ b/lib/is-config-at-home-root.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.isConfigAtHomeRoot = isConfigAtHomeRoot;
+exports.default = isConfigAtHomeRoot;
 
 var _userHome = require('user-home');
 

--- a/lib/is-config-at-home-root.js
+++ b/lib/is-config-at-home-root.js
@@ -1,10 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = isConfigAtHomeRoot;
-
 var _userHome = require('user-home');
 
 var _userHome2 = _interopRequireDefault(_userHome);
@@ -23,6 +18,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  */
 /* eslint-disable import/prefer-default-export */
 
-function isConfigAtHomeRoot(configPath) {
+module.exports = function isConfigAtHomeRoot(configPath) {
   return (0, _path.dirname)(configPath) === _userHome2.default;
-}
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,21 +1,16 @@
 'use strict';
 'use babel';
 
-var _path = require('path');
-
-var _path2 = _interopRequireDefault(_path);
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 
 var _atom = require('atom');
 
-var _helpers = require('./helpers');
-
-var _workerHelpers = require('./worker-helpers');
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 
+// Dependencies
+let path;
+let helpers;
+let workerHelpers;
 let isConfigAtHomeRoot;
 
 // Configuration
@@ -24,6 +19,12 @@ let showRule;
 let ignoredRulesWhenModified;
 let ignoredRulesWhenFixing;
 let disableWhenNoEslintConfig;
+
+// Internal functions
+const idsToIgnoredRules = ruleIds => ruleIds.reduce((ids, id) => {
+  ids[id] = 0; // 0 is the severity to turn off a rule
+  return ids;
+}, {});
 
 module.exports = {
   activate() {
@@ -36,16 +37,20 @@ module.exports = {
     this.active = true;
     this.worker = null;
     const initializeWorker = () => {
-      var _spawnWorker = (0, _helpers.spawnWorker)();
+      if (!helpers) {
+        helpers = require('./helpers');
+      }
 
-      const worker = _spawnWorker.worker,
-            subscription = _spawnWorker.subscription;
+      var _helpers$spawnWorker = helpers.spawnWorker();
+
+      const worker = _helpers$spawnWorker.worker,
+            subscription = _helpers$spawnWorker.subscription;
 
       this.worker = worker;
       this.subscriptions.add(subscription);
       worker.onDidExit(() => {
         if (this.active) {
-          (0, _helpers.showError)('Worker died unexpectedly', 'Check your console for more ' + 'info. A new worker will be spawned instantly.');
+          helpers.showError('Worker died unexpectedly', 'Check your console for more ' + 'info. A new worker will be spawned instantly.');
           setTimeout(initializeWorker, 1000);
         }
       });
@@ -74,15 +79,21 @@ module.exports = {
           if (this.worker === null) {
             initializeWorker();
           }
+          if (!path) {
+            path = require('path');
+          }
           if (!isConfigAtHomeRoot) {
             isConfigAtHomeRoot = require('./is-config-at-home-root');
+          }
+          if (!workerHelpers) {
+            workerHelpers = require('./worker-helpers');
           }
           const filePath = editor.getPath();
           const projectPath = atom.project.relativizePath(filePath)[0];
 
           // Do not try to fix if linting should be disabled
-          const fileDir = _path2.default.dirname(filePath);
-          const configPath = (0, _workerHelpers.getConfigPath)(fileDir);
+          const fileDir = path.dirname(filePath);
+          const configPath = workerHelpers.getConfigPath(fileDir);
           const noProjectConfig = configPath === null || isConfigAtHomeRoot(configPath);
           if (noProjectConfig && disableWhenNoEslintConfig) return;
 
@@ -116,7 +127,10 @@ module.exports = {
           if (_this.worker === null) {
             initializeWorker();
           }
-          const debugString = yield (0, _helpers.generateDebugString)(_this.worker);
+          if (!helpers) {
+            helpers = require('./helpers');
+          }
+          const debugString = yield helpers.generateDebugString(_this.worker);
           const notificationOptions = { detail: debugString, dismissable: true };
           atom.notifications.addInfo('linter-eslint debugging information', notificationOptions);
         });
@@ -174,11 +188,11 @@ module.exports = {
     }));
 
     this.subscriptions.add(atom.config.observe('linter-eslint.rulesToSilenceWhileTyping', ids => {
-      ignoredRulesWhenModified = (0, _helpers.idsToIgnoredRules)(ids);
+      ignoredRulesWhenModified = idsToIgnoredRules(ids);
     }));
 
     this.subscriptions.add(atom.config.observe('linter-eslint.rulesToDisableWhileFixing', ids => {
-      ignoredRulesWhenFixing = (0, _helpers.idsToIgnoredRules)(ids);
+      ignoredRulesWhenFixing = idsToIgnoredRules(ids);
     }));
 
     window.requestIdleCallback(initializeWorker);
@@ -228,7 +242,10 @@ module.exports = {
              */
             return null;
           }
-          return (0, _helpers.processESLintMessages)(response, textEditor, showRule, this.worker);
+          if (!helpers) {
+            helpers = require('./helpers');
+          }
+          return helpers.processESLintMessages(response, textEditor, showRule, this.worker);
         });
       }
     };

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,21 @@ module.exports = {
     this.subscriptions = new _atom.CompositeDisposable();
     this.active = true;
     this.worker = null;
+    const initializeWorker = () => {
+      var _spawnWorker = (0, _helpers.spawnWorker)();
+
+      const worker = _spawnWorker.worker,
+            subscription = _spawnWorker.subscription;
+
+      this.worker = worker;
+      this.subscriptions.add(subscription);
+      worker.onDidExit(() => {
+        if (this.active) {
+          (0, _helpers.showError)('Worker died unexpectedly', 'Check your console for more ' + 'info. A new worker will be spawned instantly.');
+          setTimeout(initializeWorker, 1000);
+        }
+      });
+    };
 
     this.subscriptions.add(atom.config.observe('linter-eslint.scopes', value => {
       // Remove any old scopes
@@ -57,6 +72,9 @@ module.exports = {
       editor.onDidSave(() => {
         const validScope = editor.getCursors().some(cursor => cursor.getScopeDescriptor().getScopesArray().some(scope => scopes.includes(scope)));
         if (validScope && atom.config.get('linter-eslint.fixOnSave')) {
+          if (this.worker === null) {
+            initializeWorker();
+          }
           const filePath = editor.getPath();
           const projectPath = atom.project.relativizePath(filePath)[0];
 
@@ -93,6 +111,9 @@ module.exports = {
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'linter-eslint:debug': (() => {
         var _ref = _asyncToGenerator(function* () {
+          if (_this.worker === null) {
+            initializeWorker();
+          }
           const debugString = yield (0, _helpers.generateDebugString)(_this.worker);
           const notificationOptions = { detail: debugString, dismissable: true };
           atom.notifications.addInfo('linter-eslint debugging information', notificationOptions);
@@ -106,6 +127,9 @@ module.exports = {
 
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'linter-eslint:fix-file': () => {
+        if (this.worker === null) {
+          initializeWorker();
+        }
         const textEditor = atom.workspace.getActiveTextEditor();
         const filePath = textEditor.getPath();
         const projectPath = atom.project.relativizePath(filePath)[0];
@@ -155,22 +179,7 @@ module.exports = {
       ignoredRulesWhenFixing = (0, _helpers.idsToIgnoredRules)(ids);
     }));
 
-    const initializeWorker = () => {
-      var _spawnWorker = (0, _helpers.spawnWorker)();
-
-      const worker = _spawnWorker.worker,
-            subscription = _spawnWorker.subscription;
-
-      this.worker = worker;
-      this.subscriptions.add(subscription);
-      worker.onDidExit(() => {
-        if (this.active) {
-          (0, _helpers.showError)('Worker died unexpectedly', 'Check your console for more ' + 'info. A new worker will be spawned instantly.');
-          setTimeout(initializeWorker, 1000);
-        }
-      });
-    };
-    initializeWorker();
+    window.requestIdleCallback(initializeWorker);
   },
   deactivate() {
     this.active = false;
@@ -192,6 +201,12 @@ module.exports = {
         let rules = {};
         if (textEditor.isModified() && Object.keys(ignoredRulesWhenModified).length > 0) {
           rules = ignoredRulesWhenModified;
+        }
+
+        if (this.worker === null) {
+          // The worker hasn't gotten a chance to initialize yet from the idle
+          // callback, return [] for now
+          return [];
         }
 
         return this.worker.request('job', {

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,13 +11,12 @@ var _helpers = require('./helpers');
 
 var _workerHelpers = require('./worker-helpers');
 
-var _isConfigAtHomeRoot = require('./is-config-at-home-root');
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 
+let isConfigAtHomeRoot;
 
 // Configuration
 const scopes = [];
@@ -75,13 +74,16 @@ module.exports = {
           if (this.worker === null) {
             initializeWorker();
           }
+          if (!isConfigAtHomeRoot) {
+            isConfigAtHomeRoot = require('./is-config-at-home-root');
+          }
           const filePath = editor.getPath();
           const projectPath = atom.project.relativizePath(filePath)[0];
 
           // Do not try to fix if linting should be disabled
           const fileDir = _path2.default.dirname(filePath);
           const configPath = (0, _workerHelpers.getConfigPath)(fileDir);
-          const noProjectConfig = configPath === null || (0, _isConfigAtHomeRoot.isConfigAtHomeRoot)(configPath);
+          const noProjectConfig = configPath === null || isConfigAtHomeRoot(configPath);
           if (noProjectConfig && disableWhenNoEslintConfig) return;
 
           let rules = {};

--- a/lib/main.js
+++ b/lib/main.js
@@ -30,7 +30,8 @@ module.exports = {
   activate() {
     var _this = this;
 
-    require('atom-package-deps').install('linter-eslint');
+    const installLinterEslintDeps = () => require('atom-package-deps').install('linter-eslint');
+    window.requestIdleCallback(installLinterEslintDeps);
 
     this.subscriptions = new _atom.CompositeDisposable();
     this.active = true;

--- a/lib/main.js
+++ b/lib/main.js
@@ -30,7 +30,7 @@ module.exports = {
   activate() {
     var _this = this;
 
-    require('atom-package-deps').install();
+    require('atom-package-deps').install('linter-eslint');
 
     this.subscriptions = new _atom.CompositeDisposable();
     this.active = true;

--- a/lib/main.js
+++ b/lib/main.js
@@ -26,12 +26,21 @@ const idsToIgnoredRules = ruleIds => ruleIds.reduce((ids, id) => {
   return ids;
 }, {});
 
+const waitOnIdle = () => new Promise(resolve => {
+  // The worker is initialized during an idle time, since the queued idle
+  // callbacks are done in order, waiting on a newly queued idle callback will
+  // ensure that the worker has been initialized
+  window.requestIdleCallback(resolve);
+});
+
 module.exports = {
   activate() {
     var _this = this;
 
     const installLinterEslintDeps = () => require('atom-package-deps').install('linter-eslint');
-    window.requestIdleCallback(installLinterEslintDeps);
+    if (!atom.inSpecMode()) {
+      window.requestIdleCallback(installLinterEslintDeps);
+    }
 
     this.subscriptions = new _atom.CompositeDisposable();
     this.active = true;
@@ -73,11 +82,15 @@ module.exports = {
     }));
 
     this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
-      editor.onDidSave(() => {
-        const validScope = editor.getCursors().some(cursor => cursor.getScopeDescriptor().getScopesArray().some(scope => scopes.includes(scope)));
+      editor.onDidSave(_asyncToGenerator(function* () {
+        const validScope = editor.getCursors().some(function (cursor) {
+          return cursor.getScopeDescriptor().getScopesArray().some(function (scope) {
+            return scopes.includes(scope);
+          });
+        });
         if (validScope && atom.config.get('linter-eslint.fixOnSave')) {
-          if (this.worker === null) {
-            initializeWorker();
+          if (_this.worker === null) {
+            yield waitOnIdle();
           }
           if (!path) {
             path = require('path');
@@ -105,27 +118,27 @@ module.exports = {
           // The fix replaces the file content and the cursor jumps automatically
           // to the beginning of the file, so save current cursor position
           const cursorPosition = editor.getCursorBufferPosition();
-          this.worker.request('job', {
+          _this.worker.request('job', {
             type: 'fix',
             config: atom.config.get('linter-eslint'),
             rules,
             filePath,
             projectPath
-          }).then(() => {
+          }).then(function () {
             // set cursor to the position before fix job
             editor.setCursorBufferPosition(cursorPosition);
-          }).catch(err => {
+          }).catch(function (err) {
             atom.notifications.addWarning(err.message);
           });
         }
-      });
+      }));
     }));
 
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'linter-eslint:debug': (() => {
-        var _ref = _asyncToGenerator(function* () {
+        var _ref2 = _asyncToGenerator(function* () {
           if (_this.worker === null) {
-            initializeWorker();
+            yield waitOnIdle();
           }
           if (!helpers) {
             helpers = require('./helpers');
@@ -136,47 +149,55 @@ module.exports = {
         });
 
         return function linterEslintDebug() {
-          return _ref.apply(this, arguments);
+          return _ref2.apply(this, arguments);
         };
       })()
     }));
 
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
-      'linter-eslint:fix-file': () => {
-        if (this.worker === null) {
-          initializeWorker();
-        }
-        const textEditor = atom.workspace.getActiveTextEditor();
-        const filePath = textEditor.getPath();
-        const projectPath = atom.project.relativizePath(filePath)[0];
+      'linter-eslint:fix-file': (() => {
+        var _ref3 = _asyncToGenerator(function* () {
+          if (_this.worker === null) {
+            yield waitOnIdle();
+          }
+          const textEditor = atom.workspace.getActiveTextEditor();
+          const filePath = textEditor.getPath();
+          const projectPath = atom.project.relativizePath(filePath)[0];
 
-        if (!textEditor || textEditor.isModified()) {
-          // Abort for invalid or unsaved text editors
-          atom.notifications.addError('Linter-ESLint: Please save before fixing');
-          return;
-        }
+          if (!textEditor || textEditor.isModified()) {
+            // Abort for invalid or unsaved text editors
+            atom.notifications.addError('Linter-ESLint: Please save before fixing');
+            return;
+          }
 
-        let rules = {};
-        if (textEditor.isModified() && Object.keys(ignoredRulesWhenFixing).length > 0) {
-          rules = ignoredRulesWhenFixing;
-        }
+          let rules = {};
+          if (textEditor.isModified() && Object.keys(ignoredRulesWhenFixing).length > 0) {
+            rules = ignoredRulesWhenFixing;
+          }
 
-        // The fix replaces the file content and the cursor jumps automatically
-        // to the beginning of the file, so save current cursor position
-        const cursorPosition = textEditor.getCursorBufferPosition();
-        this.worker.request('job', {
-          type: 'fix',
-          config: atom.config.get('linter-eslint'),
-          rules,
-          filePath,
-          projectPath
-        }).then(response => atom.notifications.addSuccess(response)).then(() => {
-          // set cursor to the position before fix job
-          textEditor.setCursorBufferPosition(cursorPosition);
-        }).catch(err => {
-          atom.notifications.addWarning(err.message);
+          // The fix replaces the file content and the cursor jumps automatically
+          // to the beginning of the file, so save current cursor position
+          const cursorPosition = textEditor.getCursorBufferPosition();
+          _this.worker.request('job', {
+            type: 'fix',
+            config: atom.config.get('linter-eslint'),
+            rules,
+            filePath,
+            projectPath
+          }).then(function (response) {
+            return atom.notifications.addSuccess(response);
+          }).then(function () {
+            // set cursor to the position before fix job
+            textEditor.setCursorBufferPosition(cursorPosition);
+          }).catch(function (err) {
+            atom.notifications.addWarning(err.message);
+          });
         });
-      }
+
+        return function linterEslintFixFile() {
+          return _ref3.apply(this, arguments);
+        };
+      })()
     }));
 
     this.subscriptions.add(atom.config.observe('linter-eslint.showRuleIdInMessage', value => {
@@ -195,59 +216,66 @@ module.exports = {
       ignoredRulesWhenFixing = idsToIgnoredRules(ids);
     }));
 
-    window.requestIdleCallback(initializeWorker);
+    // Initialize the worker during an idle time, with a maximum wait of 5 seconds
+    window.requestIdleCallback(initializeWorker, { timeout: 5000 });
   },
   deactivate() {
     this.active = false;
     this.subscriptions.dispose();
   },
   provideLinter() {
+    var _this2 = this;
+
     return {
       name: 'ESLint',
       grammarScopes: scopes,
       scope: 'file',
       lintOnFly: true,
-      lint: textEditor => {
-        const text = textEditor.getText();
-        if (text.length === 0) {
-          return Promise.resolve([]);
-        }
-        const filePath = textEditor.getPath();
-
-        let rules = {};
-        if (textEditor.isModified() && Object.keys(ignoredRulesWhenModified).length > 0) {
-          rules = ignoredRulesWhenModified;
-        }
-
-        if (this.worker === null) {
-          // The worker hasn't gotten a chance to initialize yet from the idle
-          // callback, return [] for now
-          return [];
-        }
-
-        return this.worker.request('job', {
-          type: 'lint',
-          contents: text,
-          config: atom.config.get('linter-eslint'),
-          rules,
-          filePath,
-          projectPath: atom.project.relativizePath(filePath)[0] || ''
-        }).then(response => {
-          if (textEditor.getText() !== text) {
-            /*
-               The editor text has been modified since the lint was triggered,
-               as we can't be sure that the results will map properly back to
-               the new contents, simply return `null` to tell the
-               `provideLinter` consumer not to update the saved results.
-             */
-            return null;
+      lint: (() => {
+        var _ref4 = _asyncToGenerator(function* (textEditor) {
+          const text = textEditor.getText();
+          if (text.length === 0) {
+            return Promise.resolve([]);
           }
-          if (!helpers) {
-            helpers = require('./helpers');
+          const filePath = textEditor.getPath();
+
+          let rules = {};
+          if (textEditor.isModified() && Object.keys(ignoredRulesWhenModified).length > 0) {
+            rules = ignoredRulesWhenModified;
           }
-          return helpers.processESLintMessages(response, textEditor, showRule, this.worker);
+
+          if (_this2.worker === null) {
+            yield waitOnIdle();
+          }
+
+          return _this2.worker.request('job', {
+            type: 'lint',
+            contents: text,
+            config: atom.config.get('linter-eslint'),
+            rules,
+            filePath,
+            projectPath: atom.project.relativizePath(filePath)[0] || ''
+          }).then(function (response) {
+            if (textEditor.getText() !== text) {
+              /*
+                 The editor text has been modified since the lint was triggered,
+                 as we can't be sure that the results will map properly back to
+                 the new contents, simply return `null` to tell the
+                 `provideLinter` consumer not to update the saved results.
+               */
+              return null;
+            }
+            if (!helpers) {
+              helpers = require('./helpers');
+            }
+            return helpers.processESLintMessages(response, textEditor, showRule, _this2.worker);
+          });
         });
-      }
+
+        return function lint(_x) {
+          return _ref4.apply(this, arguments);
+        };
+      })()
     };
   }
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,8 @@ var _atom = require('atom');
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 
 // Dependencies
+// NOTE: We are not directly requiring these in order to reduce the time it
+// takes to require this file as that causes delays in Atom loading this package
 let path;
 let helpers;
 let workerHelpers;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -17,6 +17,8 @@ var Helpers = _interopRequireWildcard(_workerHelpers);
 
 var _isConfigAtHomeRoot = require('./is-config-at-home-root');
 
+var _isConfigAtHomeRoot2 = _interopRequireDefault(_isConfigAtHomeRoot);
+
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -82,7 +84,7 @@ function fixJob(_ref2) {
 
   const cliEngineOptions = Helpers.getCLIEngineOptions(type, config, rules, relativeFilePath, fileDir, configPath);
 
-  const noProjectConfig = configPath === null || (0, _isConfigAtHomeRoot.isConfigAtHomeRoot)(configPath);
+  const noProjectConfig = configPath === null || (0, _isConfigAtHomeRoot2.default)(configPath);
   if (noProjectConfig && config.disableWhenNoEslintConfig) {
     job.response = [];
   } else if (type === 'lint') {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
       "atom": "true"
     },
     "env": {
-      "node": true
+      "node": true,
+      "browser": true
     }
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,8 +10,6 @@ import { generateRange } from 'atom-linter'
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { Disposable, Range } from 'atom'
 
-const RULE_OFF_SEVERITY = 0
-
 export function spawnWorker() {
   const env = Object.create(process.env)
 
@@ -51,13 +49,6 @@ export function showError(givenMessage, givenDetail = null) {
     detail,
     dismissable: true
   })
-}
-
-export function idsToIgnoredRules(ruleIds = []) {
-  return ruleIds.reduce((ids, id) => {
-    ids[id] = RULE_OFF_SEVERITY
-    return ids
-  }, {})
 }
 
 function validatePoint(textEditor, line, col) {

--- a/src/is-config-at-home-root.js
+++ b/src/is-config-at-home-root.js
@@ -11,6 +11,6 @@ import { dirname } from 'path'
  * @param  {string}  configPath - The path of the config file being checked
  * @return {Boolean}              True if the file is directly in the current user's home
  */
-export default function isConfigAtHomeRoot(configPath) {
+module.exports = function isConfigAtHomeRoot(configPath) {
   return (dirname(configPath) === userHome)
 }

--- a/src/is-config-at-home-root.js
+++ b/src/is-config-at-home-root.js
@@ -11,6 +11,6 @@ import { dirname } from 'path'
  * @param  {string}  configPath - The path of the config file being checked
  * @return {Boolean}              True if the file is directly in the current user's home
  */
-export function isConfigAtHomeRoot(configPath) {
+export default function isConfigAtHomeRoot(configPath) {
   return (dirname(configPath) === userHome)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import {
   generateDebugString,
 } from './helpers'
 import { getConfigPath } from './worker-helpers'
-import { isConfigAtHomeRoot } from './is-config-at-home-root'
+let isConfigAtHomeRoot
 
 // Configuration
 const scopes = []
@@ -67,6 +67,9 @@ module.exports = {
         if (validScope && atom.config.get('linter-eslint.fixOnSave')) {
           if (this.worker === null) {
             initializeWorker()
+          }
+          if (!isConfigAtHomeRoot) {
+            isConfigAtHomeRoot = require('./is-config-at-home-root')
           }
           const filePath = editor.getPath()
           const projectPath = atom.project.relativizePath(filePath)[0]

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,8 @@
 import { CompositeDisposable } from 'atom'
 
 // Dependencies
+// NOTE: We are not directly requiring these in order to reduce the time it
+// takes to require this file as that causes delays in Atom loading this package
 let path
 let helpers
 let workerHelpers

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,8 @@ let disableWhenNoEslintConfig
 
 module.exports = {
   activate() {
-    require('atom-package-deps').install('linter-eslint')
+    const installLinterEslintDeps = () => require('atom-package-deps').install('linter-eslint')
+    window.requestIdleCallback(installLinterEslintDeps)
 
     this.subscriptions = new CompositeDisposable()
     this.active = true

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ let disableWhenNoEslintConfig
 
 module.exports = {
   activate() {
-    require('atom-package-deps').install()
+    require('atom-package-deps').install('linter-eslint')
 
     this.subscriptions = new CompositeDisposable()
     this.active = true

--- a/src/worker.js
+++ b/src/worker.js
@@ -6,7 +6,7 @@ import Path from 'path'
 import { create } from 'process-communication'
 import { FindCache, findCached } from 'atom-linter'
 import * as Helpers from './worker-helpers'
-import { isConfigAtHomeRoot } from './is-config-at-home-root'
+import isConfigAtHomeRoot from './is-config-at-home-root'
 
 process.title = 'linter-eslint helper'
 


### PR DESCRIPTION
Reduce activation time of the package by deferring some actions for a later idle time and lazily requiring imports where possible. On my system this reduces package activation from an average of 177 ms down to 7 ms. The remaining 7 ms is largely taken up with Atom internals, with only 1.3 ms being under our control in any manner.

Fixes #871.