### PR TITLE
Revert #853

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -234,9 +234,6 @@ module.exports = {
       rules = ignoredRulesWhenFixing
     }
 
-    // The fix replaces the file content and the cursor jumps automatically
-    // to the beginning of the file, so save current cursor position
-    const cursorPosition = textEditor.getCursorBufferPosition()
     if (!helpers) {
       helpers = require('./helpers')
     }
@@ -256,8 +253,6 @@ module.exports = {
       if (!isSave) {
         atom.notifications.addSuccess(response)
       }
-      // Set cursor to the position before fix job
-      textEditor.setCursorBufferPosition(cursorPosition)
     } catch (err) {
       atom.notifications.addWarning(err.message)
     }


### PR DESCRIPTION
Reverts #853.

From the testing done so far this code either:

* Does exactly what Atom is already doing itself if the fix doesn't replace the entire file
* Doesn't actually work if the entire file is replaced (rare to reproduce this)

So in either case the code is doing nothing but adding complexity to the codebase.