### PR TITLE
Cancel pending idle callbacks

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,6 +22,9 @@ let ignoredRulesWhenModified;
 let ignoredRulesWhenFixing;
 let disableWhenNoEslintConfig;
 
+// Internal variables
+const idleCallbacks = new Set();
+
 // Internal functions
 const idsToIgnoredRules = ruleIds => ruleIds.reduce((ids, id) => {
   ids[id] = 0; // 0 is the severity to turn off a rule
@@ -32,17 +35,26 @@ const waitOnIdle = () => new Promise(resolve => {
   // The worker is initialized during an idle time, since the queued idle
   // callbacks are done in order, waiting on a newly queued idle callback will
   // ensure that the worker has been initialized
-  window.requestIdleCallback(resolve);
+  const callbackID = window.requestIdleCallback(() => {
+    idleCallbacks.delete(callbackID);
+    resolve();
+  });
+  idleCallbacks.add(callbackID);
 });
 
 module.exports = {
   activate() {
     var _this = this;
 
-    const installLinterEslintDeps = () => require('atom-package-deps').install('linter-eslint');
-    if (!atom.inSpecMode()) {
-      window.requestIdleCallback(installLinterEslintDeps);
-    }
+    let callbackID;
+    const installLinterEslintDeps = () => {
+      idleCallbacks.delete(callbackID);
+      if (!atom.inSpecMode()) {
+        require('atom-package-deps').install('linter-eslint');
+      }
+    };
+    callbackID = window.requestIdleCallback(installLinterEslintDeps);
+    idleCallbacks.add(callbackID);
 
     this.subscriptions = new _atom.CompositeDisposable();
     this.active = true;
@@ -222,6 +234,8 @@ module.exports = {
     window.requestIdleCallback(initializeWorker, { timeout: 5000 });
   },
   deactivate() {
+    idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+    idleCallbacks.clear();
     this.active = false;
     this.subscriptions.dispose();
   },


### PR DESCRIPTION
If the package is requested to be deactivated before a pending idle callback has ran we should cancel that callback as there is no point in running it.

Should have been part of #875, but I hadn't thought of this race condition yet 😛.