### PR TITLE
chore(package): update atom-package-deps to version 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.0.1",
+    "atom-package-deps": "^4.6.0",
     "consistent-path": "^2.0.1",
     "escape-html": "^1.0.3",
     "eslint": "^3.6.0",


### PR DESCRIPTION
Explicitly updating to this version since it cuts the time to require this dependency by 3-4x. It's already moved to an idle callback, but why not make sure that runs as fast as possible as well? 😛