### PR TITLE
Allow ESLint to fully determine config when possible

### DIFF
--- a/lib/worker-helpers.js
+++ b/lib/worker-helpers.js
@@ -159,11 +159,6 @@ function getRelativePath(fileDir, filePath, config) {
 }
 
 function getCLIEngineOptions(type, config, rules, filePath, fileDir, givenConfigPath) {
-  let configPath;
-  if (givenConfigPath === null) {
-    configPath = config.eslintrcPath || null;
-  } else configPath = givenConfigPath;
-
   const cliEngineConfig = {
     rules,
     ignore: !config.disableEslintIgnore,
@@ -184,8 +179,10 @@ function getCLIEngineOptions(type, config, rules, filePath, fileDir, givenConfig
       cliEngineConfig.rulePaths = [rulesDir];
     }
   }
-  if (configPath) {
-    cliEngineConfig.configFile = (0, _resolveEnv2.default)(configPath);
+
+  if (givenConfigPath === null && config.eslintrcPath) {
+    // If we didn't find a configuration use the fallback from the settings
+    cliEngineConfig.configFile = (0, _resolveEnv2.default)(config.eslintrcPath);
   }
 
   return cliEngineConfig;

--- a/spec/fixtures/badCache/.eslintrc.js
+++ b/spec/fixtures/badCache/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  root: true,
+  rules: {
+    'no-undef': 'error'
+  }
+}

--- a/spec/fixtures/badCache/temp/foo.js
+++ b/spec/fixtures/badCache/temp/foo.js
@@ -1,0 +1,3 @@
+function foo() {
+  console.log(bar);
+}

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -136,11 +136,6 @@ export function getRelativePath(fileDir, filePath, config) {
 }
 
 export function getCLIEngineOptions(type, config, rules, filePath, fileDir, givenConfigPath) {
-  let configPath
-  if (givenConfigPath === null) {
-    configPath = config.eslintrcPath || null
-  } else configPath = givenConfigPath
-
   const cliEngineConfig = {
     rules,
     ignore: !config.disableEslintIgnore,
@@ -161,8 +156,10 @@ export function getCLIEngineOptions(type, config, rules, filePath, fileDir, give
       cliEngineConfig.rulePaths = [rulesDir]
     }
   }
-  if (configPath) {
-    cliEngineConfig.configFile = resolveEnv(configPath)
+
+  if (givenConfigPath === null && config.eslintrcPath) {
+    // If we didn't find a configuration use the fallback from the settings
+    cliEngineConfig.configFile = resolveEnv(config.eslintrcPath)
   }
 
   return cliEngineConfig


### PR DESCRIPTION
ESLint already handles grabbing the configuration for a file for us, but we have actually been preventing this from working properly by always specifying the path to what we determined to be the configuration file.

Since we really only need that to determine if we should run ESLint at all, stop sending that to ESLint unless we are overriding it with a fallback.

Fixes #892.