### PR TITLE
Preserve `.eslintcache` on fixes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -215,6 +215,13 @@ module.exports = {
     const fileDir = path.dirname(filePath)
     const projectPath = atom.project.relativizePath(filePath)[0]
 
+    // Get the text from the editor, so we can use executeOnText
+    const text = textEditor.getText()
+    // Do not try to make fixes on an empty file
+    if (text.length === 0) {
+      return
+    }
+
     // Do not try to fix if linting should be disabled
     const configPath = workerHelpers.getConfigPath(fileDir)
     const noProjectConfig = (configPath === null || isConfigAtHomeRoot(configPath))
@@ -241,6 +248,7 @@ module.exports = {
       const response = await helpers.sendJob(this.worker, {
         type: 'fix',
         config: atom.config.get('linter-eslint'),
+        contents: text,
         rules,
         filePath,
         projectPath

--- a/src/worker.js
+++ b/src/worker.js
@@ -29,14 +29,11 @@ function shouldBeReported(problem) {
 
 function lintJob({ cliEngineOptions, contents, eslint, filePath }) {
   const cliEngine = new eslint.CLIEngine(cliEngineOptions)
-
-  return typeof contents === 'string'
-    ? cliEngine.executeOnText(contents, filePath)
-    : cliEngine.executeOnFiles([filePath])
+  return cliEngine.executeOnText(contents, filePath)
 }
 
-function fixJob({ cliEngineOptions, eslint, filePath }) {
-  const report = lintJob({ cliEngineOptions, eslint, filePath })
+function fixJob({ cliEngineOptions, contents, eslint, filePath }) {
+  const report = lintJob({ cliEngineOptions, contents, eslint, filePath })
 
   eslint.CLIEngine.outputFixes(report)
 
@@ -73,7 +70,7 @@ module.exports = async function () {
       const report = lintJob({ cliEngineOptions, contents, eslint, filePath })
       response = report.results.length ? report.results[0].messages.filter(shouldBeReported) : []
     } else if (type === 'fix') {
-      response = fixJob({ cliEngineOptions, eslint, filePath })
+      response = fixJob({ cliEngineOptions, contents, eslint, filePath })
     } else if (type === 'debug') {
       const modulesDir = Path.dirname(findCached(fileDir, 'node_modules/eslint') || '')
       response = Helpers.findESLintDirectory(modulesDir, config)


### PR DESCRIPTION
Fixes #635 

The main point of this PR is to avoid deleting the `.eslintcache` file when performing fix jobs in `linter-eslint`.  Previously, they were deleted because if ESLint is run without the `cache` option, it will automatically delete any existing cache files.  `linter-eslint` doesn't delete the cache on regular `lint` jobs because it uses `executeOnText`, which bypasses the cache and does not delete it.  

**Update**: I've changed this PR to use `executeOnText` for fix jobs as suggested by @not-an-aardvark in https://github.com/AtomLinter/linter-eslint/pull/873#discussion_r110076641.  It's a much better solution than my first approach.

~~The approach I took was fairly simplistic.  We will search for a `.eslintcache` file, and if we find it, we will set `cache` for fix jobs.  There is a slight danger here that we may create extra `.eslintcache` files in unexpected locations, because that setting will also _create_ cache files if none exist.  In my own testing so far I haven't experienced that problem, but we should be on the lookout for it in more complicated project structures.~~

~~At this time I think it's reasonable to only consider files named `.eslintcache`, as that is the default and most common.  If there is overwhelming demand for a config setting, we can consider that, but for now I'd like to keep it as simple as possible.~~