### PR TITLE
Handle fatal syntax errors gracefully

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -208,8 +208,9 @@ const generateInvalidTrace = async (
  */
 export async function processESLintMessages(response, textEditor, showRule, worker) {
   return Promise.all(response.map(async ({
-    message, line, severity, ruleId, column, fix, endLine, endColumn
+    fatal, message: originalMessage, line, severity, ruleId, column, fix, endLine, endColumn
   }) => {
+    const message = fatal ? originalMessage.split('\n')[0] : originalMessage
     const filePath = textEditor.getPath()
     const textBuffer = textEditor.getBuffer()
     let linterFix = null


### PR DESCRIPTION
ESLint outputs context in the most recent versions which is useless inside Atom

Can be seen in a lot of issues across the repos, https://github.com/steelbrain/linter-ui-default/issues/309 is the most recent one
