### PR TITLE
Fix builds of Atom beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ### Project specific config ###
 language: generic
+dist: trusty
 
 matrix:
   include:


### PR DESCRIPTION
Atom v1.18.0 brings in a version of APM that requires Trusty on Travis-CI.

See https://github.com/atom/atom/issues/14440 for more details.