### PR TITLE
Fix embedded HTML scope with custom scopes

### DIFF
--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -507,4 +507,25 @@ describe('The eslint provider for Linter', () => {
       fs.unlinkSync(newConfigPath)
     })
   })
+
+  describe('works with HTML files', () => {
+    const embeddedScope = 'source.js.embedded.html'
+    const scopes = linterProvider.grammarScopes
+
+    it('adds the HTML scope when the setting is enabled', () => {
+      expect(scopes.includes(embeddedScope)).toBe(false)
+      atom.config.set('linter-eslint.lintHtmlFiles', true)
+      expect(scopes.includes(embeddedScope)).toBe(true)
+      atom.config.set('linter-eslint.lintHtmlFiles', false)
+      expect(scopes.includes(embeddedScope)).toBe(false)
+    })
+
+    it('keeps the HTML scope with custom scopes', () => {
+      expect(scopes.includes(embeddedScope)).toBe(false)
+      atom.config.set('linter-eslint.lintHtmlFiles', true)
+      expect(scopes.includes(embeddedScope)).toBe(true)
+      atom.config.set('linter-eslint.scopes', ['foo.bar'])
+      expect(scopes.includes(embeddedScope)).toBe(true)
+    })
+  })
 })

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ let isConfigAtHomeRoot
 // Configuration
 const scopes = []
 let showRule
+let lintHtmlFiles
 let ignoredRulesWhenModified
 let ignoredRulesWhenFixing
 let disableWhenNoEslintConfig
@@ -55,22 +56,27 @@ module.exports = {
     this.subscriptions = new CompositeDisposable()
     this.worker = null
 
+    const embeddedScope = 'source.js.embedded.html'
+    this.subscriptions.add(atom.config.observe('linter-eslint.lintHtmlFiles',
+      (value) => {
+        lintHtmlFiles = value
+        if (lintHtmlFiles) {
+          scopes.push(embeddedScope)
+        } else if (scopes.indexOf(embeddedScope) !== -1) {
+          scopes.splice(scopes.indexOf(embeddedScope), 1)
+        }
+      })
+    )
+
     this.subscriptions.add(
       atom.config.observe('linter-eslint.scopes', (value) => {
         // Remove any old scopes
         scopes.splice(0, scopes.length)
         // Add the current scopes
         Array.prototype.push.apply(scopes, value)
-      })
-    )
-
-    const embeddedScope = 'source.js.embedded.html'
-    this.subscriptions.add(atom.config.observe('linter-eslint.lintHtmlFiles',
-      (lintHtmlFiles) => {
-        if (lintHtmlFiles) {
+        // Ensure HTML linting still works if the setting is updated
+        if (lintHtmlFiles && !scopes.includes(embeddedScope)) {
           scopes.push(embeddedScope)
-        } else if (scopes.indexOf(embeddedScope) !== -1) {
-          scopes.splice(scopes.indexOf(embeddedScope), 1)
         }
       })
     )


### PR DESCRIPTION
Previously when a custom scope was edited and embedded HTML was enabled, the linting of embedded HTML would temporarily break till Atom was restarted or the embedded HTML setting was toggled off and on. This ensures the scope is in the current scope list if it is enabled.

Fixes #823.