### PR TITLE
Cleanup and update the developer documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,3 @@
 
 # (binary is a macro for -text -diff)
 *.png binary
-
-# Exclude build-time .babelrc config from APM pkg (#796)
-.babelrc export-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,10 @@ If you would like to contribute enhancements or fixes, please do the following:
 2.  Run `npm install` to setup all dependencies.
 3.  Hack on a separate topic branch created from the latest `master`.
 4.  Check for lint errors with `npm run lint` or use `linter-eslint` within Atom.
-5.  Commit the changes and push the topic branch to your fork.
-6.  Make a pull request to the main repo.
-7.  Welcome to the club!
+5.  Run the package specs.
+6.  Commit the changes and push the topic branch to your fork.
+7.  Make a pull request to the main repo.
+8.  Welcome to the club!
 
 ## Guidelines
 
@@ -19,6 +20,12 @@ Please note that modifications should follow these coding guidelines:
 *   Indent is 2 spaces.
 *   Code should pass the `eslint` linter.
 *   Vertical whitespace helps readability, don’t be afraid to use it!
+
+## Testing
+
+You can run the specs for this package locally by either running `apm test` from
+the project directory, or from within Atom by going to View -> Developer -> Run
+Package Specs.
 
 ## Discussion
 If you have any questions during development you can join the #linter-plugin-dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,33 +4,25 @@
 
 If you would like to contribute enhancements or fixes, please do the following:
 
-1.  Fork the plugin repository
-2.  Run `npm install` to setup all dependencies
-3.  Hack on a separate topic branch created from the latest `master`. Changes to
-    the package code should be made to the files in the `src` directory.
-4.  Check for lint errors with `npm run lint` or Atom and `linter-eslint`.
-5.  Run `npm run compile` to generate compiled files under `lib`.
-6.  Commit the changes under `src` and `lib` and push the topic branch
-7.  Make a pull request
-8.  Welcome to the club!
+1.  Fork the package repository.
+2.  Run `npm install` to setup all dependencies.
+3.  Hack on a separate topic branch created from the latest `master`.
+4.  Check for lint errors with `npm run lint` or use `linter-eslint` within Atom.
+5.  Commit the changes and push the topic branch to your fork.
+6.  Make a pull request to the main repo.
+7.  Welcome to the club!
 
 ## Guidelines
 
 Please note that modifications should follow these coding guidelines:
 
-*   Indent is 2 spaces
-*   Code should pass the `eslint` linter
-*   Vertical whitespace helps readability, don’t be afraid to use it
+*   Indent is 2 spaces.
+*   Code should pass the `eslint` linter.
+*   Vertical whitespace helps readability, don’t be afraid to use it!
 
 ## Discussion
-If you have any questions during development you can join the #linter-plugin-dev channel on [Atom's Slack instance](http://atom-slack.herokuapp.com/).
-
-## Building
-
-The simplest procedure is to run `npm run watch` which executes
-`ucompiler watch`. UCompiler will automatically start watching the `src`
-directory and will recompile any changed files. If you prefer to compile
-them manually, use `npm run compile` which will run `ucompiler go` for you.
+If you have any questions during development you can join the #linter-plugin-dev
+channel on [Atom's Slack instance](http://atom-slack.herokuapp.com/).
 
 ## Releasing
 
@@ -38,16 +30,14 @@ Project members with push access to the repository also have the permissions
 needed to release a new version.  If there have been changes to the project and
 the team decides it is time for a new release, the process is to:
 
-1. Update `CHANGELOG.md` with the planned version number and a short bulleted
-list of major changes.  Include pull request numbers if applicable.
-1. Run `npm run compile` to build the files in `lib/`
-1. Commit the changelog and any `lib/` changes to master.
-1. Publish a new version with `apm publish {major|minor|patch}`, using semver to
-decide what type of version should be released.
-1. `apm` will then automatically:
-  * Update `package.json` with the new version number
-  * Commit the changed `package.json` to master
-  * Create a git tag for the new version and push it to GitHub
-  * Publish the package to the Atom package manager
+1.  Update `CHANGELOG.md` with the planned `semver` version number and a short
+    bulleted list of major changes.  Include pull request numbers if applicable.
+2.  Update `package.json` with the new version number.
+3.  Commit the changed `package.json` and `CHANGELOG.md` to master
+4.  Create a git tag for the new version and push it to GitHub
+  * To create the (signed) tag: `git tag -s -m "vx.y.z" vx.y.z`
+  * To push to GitHub: `git push --follow-tags`
+5.  Publish the package to the Atom package manager
+  * `apm publish --tag vx.y.z`
 
 Thank you for helping out!


### PR DESCRIPTION
Update the documentation for the simplified process now that the transpilation is in place. Also removes reference to the `.babelrc` file that no longer exists.