### PR TITLE
Prevent Atom transpilation from searching for .babelrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,8 @@
           "presets": [
             "node5"
           ],
-          "sourceMaps": "inline"
+          "sourceMaps": "inline",
+          "babelrc": false
         },
         "cacheKeyFiles": [
           "package.json"


### PR DESCRIPTION
The built in transpilation was pulling in `.babelrc` files from user's machines, including locations like `~/.babelrc`. This was causing the package to not be transpiled in a manner compatible with Atom.

Fixes #920.