### PR TITLE
chore(package): update eslint-plugin-import to version 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   "devDependencies": {
     "eslint": "^3.17.0",
     "eslint-config-airbnb-base": "^11.0.0",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-import": "^2.6.0",
     "jasmine-fix": "^1.0.1",
     "rimraf": "^2.5.4"
   },


### PR DESCRIPTION
This is likely to be the minimum version needed for the upcoming ESLint v4 compatible version of `eslint-config-airbnb-base`.

Closes #947.