### PR TITLE
Force atom-babel6-transpiler to not set BABEL_ENV

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
       "glob": "{src,spec}/*.js",
       "transpiler": "atom-babel6-transpiler",
       "options": {
+        "setBabelEnv": false,
         "babel": {
           "presets": [
             "node5"


### PR DESCRIPTION
Although we aren't utilizing it, `atom-babel6-transpiler` was setting `BABEL_ENV` to `undefined` whenever this package was transpiled leading to other Atom packages that use that environment variable to become corrupted.

Fixes #921.