### PR TITLE
Ensure that projectPath has a value

### DIFF
--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -60,7 +60,7 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
     eslintDir = Path.join(config.advancedLocalNodeModules || '', 'eslint')
   } else {
     locationType = 'advanced specified'
-    eslintDir = Path.join(projectPath, config.advancedLocalNodeModules, 'eslint')
+    eslintDir = Path.join(projectPath || '', config.advancedLocalNodeModules, 'eslint')
   }
   if (isDirectory(eslintDir)) {
     return {
@@ -101,7 +101,7 @@ export function refreshModulesPath(modulesDir) {
 export function getESLintInstance(fileDir, config, projectPath) {
   const modulesDir = Path.dirname(findCached(fileDir, 'node_modules/eslint') || '')
   refreshModulesPath(modulesDir)
-  return getESLintFromDirectory(modulesDir, config, projectPath || '')
+  return getESLintFromDirectory(modulesDir, config, projectPath)
 }
 
 export function getConfigPath(fileDir) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -55,7 +55,7 @@ module.exports = async function () {
       response = fixJob({ cliEngineOptions, contents, eslint, filePath })
     } else if (type === 'debug') {
       const modulesDir = Path.dirname(findCached(fileDir, 'node_modules/eslint') || '')
-      response = Helpers.findESLintDirectory(modulesDir, config)
+      response = Helpers.findESLintDirectory(modulesDir, config, projectPath)
     }
     emit(emitKey, response)
   })


### PR DESCRIPTION
Make sure that when finding the ESLint directory the projectPath variable is either set, or swapped for an empty string to prevent an error.

Closes #958.