### PR TITLE
Add an ESLint Fix right click command

### DIFF
--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -573,4 +573,21 @@ describe('The eslint provider for Linter', () => {
       expect(messages[0].solutions).not.toBeDefined()
     })
   })
+
+  describe("registers an 'ESLint Fix' right click menu command", () => {
+    // NOTE: Reaches into the private data of the ContextMenuManager, there is
+    // no public method to check this though so...
+    expect(atom.contextMenu.itemSets.some(itemSet =>
+      // Matching selector...
+      itemSet.selector === 'atom-text-editor:not(.mini), .overlayer' &&
+      itemSet.items.some(item =>
+        // Matching command...
+        item.command === 'linter-eslint:fix-file' &&
+        // Matching label
+        item.label === 'ESLint Fix' &&
+        // And has a function controlling display
+        typeof item.shouldDisplay === 'function'
+      )
+    ))
+  })
 })


### PR DESCRIPTION
Add an "ESLint Fix" command to the right click menu when it is the active editor and is listed as a valid scope according to the current settings.

Fixes #955.