### PR TITLE
Try to set cwd to project root dir if no .eslintignore is found

### DIFF
--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -50,7 +50,8 @@ function copyFileToDir(fileToCopyPath, destinationDir) {
  * @param  {string} fileToCopyPath  Path of the file to be copied
  * @return {string}                 Full path of the file in copy destination
  */
-function copyFileToTempDir(fileToCopyPath) {
+// eslint-disable-next-line import/prefer-default-export
+export function copyFileToTempDir(fileToCopyPath) {
   return new Promise(async (resolve) => {
     const tempFixtureDir = fs.mkdtempSync(tmpdir() + path.sep)
     resolve(await copyFileToDir(fileToCopyPath, tempFixtureDir))

--- a/spec/worker-helpers-spec.js
+++ b/spec/worker-helpers-spec.js
@@ -1,7 +1,9 @@
 'use babel'
 
 import * as Path from 'path'
+import rimraf from 'rimraf'
 import * as Helpers from '../src/worker-helpers'
+import { copyFileToTempDir } from './linter-eslint-spec'
 
 const getFixturesPath = path => Path.join(__dirname, 'fixtures', path)
 
@@ -176,6 +178,37 @@ describe('Worker Helpers', () => {
       const relativePath =
         Helpers.getRelativePath(fixtureDir, fixtureFile, { disableEslintIgnore: true })
       expect(relativePath).toBe('ignored.js')
+    })
+
+    it('returns the path relative to the project dir if provided when no ignore file is found', async () => {
+      const fixtureFile = getFixturesPath(Path.join('files', 'good.js'))
+      // Copy the file to a temporary folder
+      const tempFixturePath = await copyFileToTempDir(fixtureFile)
+      const tempDir = Path.dirname(tempFixturePath)
+      const filepath = Path.join(tempDir, 'good.js')
+      const tempDirParent = Path.dirname(tempDir)
+
+      const relativePath = Helpers.getRelativePath(tempDir, filepath, {}, tempDirParent)
+      // Since the project is the parent of the temp dir, the relative path should be
+      // the dir containing the file, plus the file. (e.g. asgln3/good.js)
+      const expectedPath = Path.join(Path.basename(tempDir), 'good.js')
+      expect(relativePath).toBe(expectedPath)
+      // Remove the temporary directory
+      rimraf.sync(tempDir)
+    })
+
+    it('returns just the file being linted if no ignore file is found and no project dir is provided', async () => {
+      const fixtureFile = getFixturesPath(Path.join('files', 'good.js'))
+      // Copy the file to a temporary folder
+      const tempFixturePath = await copyFileToTempDir(fixtureFile)
+      const tempDir = Path.dirname(tempFixturePath)
+      const filepath = Path.join(tempDir, 'good.js')
+
+      const relativePath = Helpers.getRelativePath(tempDir, filepath, {}, null)
+      expect(relativePath).toBe('good.js')
+
+      // Remove the temporary directory
+      rimraf.sync(tempDir)
     })
   })
 })

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -126,14 +126,22 @@ export function getConfigPath(fileDir) {
   return null
 }
 
-export function getRelativePath(fileDir, filePath, config) {
+export function getRelativePath(fileDir, filePath, config, projectPath) {
   const ignoreFile = config.disableEslintIgnore ? null : findCached(fileDir, '.eslintignore')
 
+  // If we can find an .eslintignore file, we can set cwd there
+  // (because they are expected to be at the project root)
   if (ignoreFile) {
     const ignoreDir = Path.dirname(ignoreFile)
     process.chdir(ignoreDir)
     return Path.relative(ignoreDir, filePath)
   }
+  // Otherwise, we'll set the cwd to the atom project root as long as that exists
+  if (projectPath) {
+    process.chdir(projectPath)
+    return Path.relative(projectPath, filePath)
+  }
+  // If all else fails, use the file location itself
   process.chdir(fileDir)
   return Path.basename(filePath)
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -41,7 +41,7 @@ module.exports = async function () {
       return
     }
 
-    const relativeFilePath = Helpers.getRelativePath(fileDir, filePath, config)
+    const relativeFilePath = Helpers.getRelativePath(fileDir, filePath, config, projectPath)
 
     const cliEngineOptions = Helpers.getCLIEngineOptions(
       type, config, rules, relativeFilePath, fileDir, configPath


### PR DESCRIPTION
This tweaks our fallback cwd and relative path resolution slightly, such that instead of falling straight back to just the directory of the file itself, we will use the base directory open in the atom editor.

If for whatever reason that is `null` (or undefined), we’ll still fall back to the file directory as before.

This approach was suggested in https://github.com/AtomLinter/linter-eslint/issues/827#issuecomment-281770220.

It's still possible for users to have a folder open that is _not_ their project root, in which case they might get strange results, but it is likely an improvement for the majority of users.

Closes #964 