### PR TITLE
Handle entire file messages

### DIFF
--- a/spec/fixtures/configs/invalid-rule/.eslintrc.js
+++ b/spec/fixtures/configs/invalid-rule/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  root: true,
+  rules: {
+    'foo-bar': 'error'
+  }
+}

--- a/spec/fixtures/configs/invalid-rule/foo.js
+++ b/spec/fixtures/configs/invalid-rule/foo.js
@@ -1,0 +1,4 @@
+var foo = 42;
+
+// Add more code that will get highlighted by a root node message.
+var bar;

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -28,6 +28,7 @@ const modifiedIgnoreSpacePath = path.join(fixturesDir,
   'modified-ignore-rule', 'foo-space.js')
 const endRangePath = path.join(fixturesDir, 'end-range', 'no-unreachable.js')
 const badCachePath = path.join(fixturesDir, 'badCache')
+const invalidRulePath = path.join(fixturesDir, 'configs', 'invalid-rule', 'foo.js')
 
 /**
  * Async helper to copy a file from one place to another on the filesystem.
@@ -589,5 +590,23 @@ describe('The eslint provider for Linter', () => {
         typeof item.shouldDisplay === 'function'
       )
     ))
+  })
+
+  describe('handles root node reports nicely', () => {
+    it("doesn't highlight the entire file", async () => {
+      const editor = await atom.workspace.open(invalidRulePath)
+      const messages = await lint(editor)
+      expect(messages.length).toBe(1)
+
+      const expected0 = "Definition for rule 'foo-bar' was not found (foo-bar)"
+      const expected0Url = 'http://eslint.org/docs/rules/foo-bar'
+
+      expect(messages[0].severity).toBe('error')
+      expect(messages[0].excerpt).toBe(expected0)
+      expect(messages[0].url).toBe(expected0Url)
+      expect(messages[0].location.file).toBe(invalidRulePath)
+      expect(messages[0].location.position).toEqual([[0, 0], [0, 13]])
+      expect(messages[0].solutions).not.toBeDefined()
+    })
   })
 })


### PR DESCRIPTION
ESLint v4 can mark the root node of a file as having an error, which would lead to the entire file being reported as the range for the file.

Check for these messages and force them to instead highlight just the first line of the file.

Fixes #908.