### PR TITLE
Normalize all config paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,11 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
     "atom-babel6-transpiler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/atom-babel6-transpiler/-/atom-babel6-transpiler-1.1.2.tgz",
@@ -937,6 +942,17 @@
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
+      }
+    },
+    "fs-plus": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+      "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+      "requires": {
+        "async": "1.5.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "underscore-plus": "1.6.6"
       }
     },
     "fs.realpath": {
@@ -1964,6 +1980,19 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "underscore-plus": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
+      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "requires": {
+        "underscore": "1.6.0"
+      }
     },
     "user-home": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "crypto-random-string": "^1.0.0",
     "eslint": "^4.6.0",
     "eslint-rule-documentation": "^1.0.18",
+    "fs-plus": "^3.0.1",
     "resolve-env": "^1.0.0",
     "user-home": "^2.0.0"
   },

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -69,7 +69,7 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
     eslintDir = Path.join(cleanPath(config.advancedLocalNodeModules), 'eslint')
   } else {
     locationType = 'advanced specified'
-    eslintDir = Path.join(projectPath || '', config.advancedLocalNodeModules, 'eslint')
+    eslintDir = Path.join(projectPath || '', cleanPath(config.advancedLocalNodeModules), 'eslint')
   }
   if (isDirectory(eslintDir)) {
     return {

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -13,11 +13,13 @@ const Cache = {
   LAST_MODULES_PATH: null
 }
 
-const cleanPath = (path) => {
-  const unTildeify = fs.normalize(path)
-  const unEnvVarify = resolveEnv(unTildeify)
-  return unEnvVarify
-}
+/**
+ * Takes a path and translates `~` to the user's home directory, and replaces
+ * all environment variables with their value.
+ * @param  {string} path The path to remove "strangeness" from
+ * @return {string}      The cleaned path
+ */
+const cleanPath = path => (path ? resolveEnv(fs.normalize(path)) : '')
 
 export function getNodePrefixPath() {
   if (Cache.NODE_PREFIX_PATH === null) {
@@ -51,7 +53,7 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
   let locationType = null
   if (config.useGlobalEslint) {
     locationType = 'global'
-    const configGlobal = config.globalNodePath && cleanPath(config.globalNodePath)
+    const configGlobal = cleanPath(config.globalNodePath)
     const prefixPath = configGlobal || getNodePrefixPath()
     // NPM on Windows and Yarn on all platforms
     eslintDir = Path.join(prefixPath, 'node_modules', 'eslint')
@@ -64,7 +66,7 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
     eslintDir = Path.join(modulesDir || '', 'eslint')
   } else if (Path.isAbsolute(cleanPath(config.advancedLocalNodeModules))) {
     locationType = 'advanced specified'
-    eslintDir = Path.join(cleanPath(config.advancedLocalNodeModules) || '', 'eslint')
+    eslintDir = Path.join(cleanPath(config.advancedLocalNodeModules), 'eslint')
   } else {
     locationType = 'advanced specified'
     eslintDir = Path.join(projectPath || '', config.advancedLocalNodeModules, 'eslint')


### PR DESCRIPTION
Enhance all paths in the configurations so that they allow the use of `~` where appropriate.

Fixes #985.