### PR TITLE
Handle errors as a lint message

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,22 +63,6 @@ export async function sendJob(worker, config) {
   })
 }
 
-export function showError(givenMessage, givenDetail = null) {
-  let detail
-  let message
-  if (givenMessage instanceof Error) {
-    // mdn.io/Destructuring_assignment#Assignment_without_declaration
-    ({ stack: detail, message } = givenMessage)
-  } else {
-    detail = givenDetail
-    message = givenMessage
-  }
-  atom.notifications.addError(`[Linter-ESLint] ${message}`, {
-    detail,
-    dismissable: true
-  })
-}
-
 function validatePoint(textBuffer, line, col) {
   // Clip the given point to a valid one, and check if it equals the original
   if (!textBuffer.clipPosition([line, col]).isEqual([line, col])) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -149,10 +149,10 @@ export async function generateDebugString(worker) {
   return details.join('\n')
 }
 
-const generateInvalidTrace = async (
+const generateInvalidTrace = async ({
   msgLine, msgCol, msgEndLine, msgEndCol,
   eslintFullRange, filePath, textEditor, ruleId, message, worker
-) => {
+}) => {
   let errMsgRange = `${msgLine + 1}:${msgCol}`
   if (eslintFullRange) {
     errMsgRange += ` - ${msgEndLine + 1}:${msgEndCol + 1}`
@@ -276,10 +276,18 @@ export async function processESLintMessages(response, textEditor, showRule, work
         // This isn't an invalid point error from `generateRange`, re-throw it
         throw err
       }
-      ret = await generateInvalidTrace(
-        msgLine, msgCol, msgEndLine, msgEndCol,
-        eslintFullRange, filePath, textEditor, ruleId, message, worker
-      )
+      ret = await generateInvalidTrace({
+        msgLine,
+        msgCol,
+        msgEndLine,
+        msgEndCol,
+        eslintFullRange,
+        filePath,
+        textEditor,
+        ruleId,
+        message,
+        worker
+      })
     }
 
     return ret

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -79,10 +79,9 @@ export function showError(givenMessage, givenDetail = null) {
   })
 }
 
-function validatePoint(textEditor, line, col) {
-  const buffer = textEditor.getBuffer()
+function validatePoint(textBuffer, line, col) {
   // Clip the given point to a valid one, and check if it equals the original
-  if (!buffer.clipPosition([line, col]).isEqual([line, col])) {
+  if (!textBuffer.clipPosition([line, col]).isEqual([line, col])) {
     throw new Error(`${line}:${col} isn't a valid point!`)
   }
 }
@@ -245,8 +244,9 @@ export async function processESLintMessages(response, textEditor, showRule, work
     let range
     try {
       if (eslintFullRange) {
-        validatePoint(textEditor, msgLine, msgCol)
-        validatePoint(textEditor, msgEndLine, msgEndCol)
+        const buffer = textEditor.getBuffer()
+        validatePoint(buffer, msgLine, msgCol)
+        validatePoint(buffer, msgEndLine, msgEndCol)
         range = [[msgLine, msgCol], [msgEndLine, msgEndCol]]
       } else {
         range = generateRange(textEditor, msgLine, msgCol)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -133,6 +133,21 @@ export async function generateDebugString(worker) {
   return details.join('\n')
 }
 
+export async function handleError(textEditor, error) {
+  const { stack, message } = error
+  // Only show the first line of the message as the excerpt
+  const excerpt = `Error while running ESLint: ${message.split('\n')[0]}.`
+  return [{
+    severity: 'error',
+    excerpt,
+    description: `<div style="white-space: pre-wrap">${message}\n<hr />${stack}</div>`,
+    location: {
+      file: textEditor.getPath(),
+      position: generateRange(textEditor),
+    },
+  }]
+}
+
 const generateInvalidTrace = async ({
   msgLine, msgCol, msgEndLine, msgEndCol,
   eslintFullRange, filePath, textEditor, ruleId, message, worker

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -239,7 +239,17 @@ export async function processESLintMessages(response, textEditor, showRule, work
       msgCol = typeof column !== 'undefined' ? column - 1 : column
     }
 
-    let ret
+    let ret = {
+      severity: severity === 1 ? 'warning' : 'error',
+      location: {
+        file: filePath,
+      }
+    }
+
+    if (ruleId) {
+      ret.url = ruleURI(ruleId).url
+    }
+
     let range
     try {
       if (eslintFullRange) {
@@ -250,17 +260,7 @@ export async function processESLintMessages(response, textEditor, showRule, work
       } else {
         range = generateRange(textEditor, msgLine, msgCol)
       }
-      ret = {
-        severity: severity === 1 ? 'warning' : 'error',
-        location: {
-          file: filePath,
-          position: range
-        }
-      }
-
-      if (ruleId) {
-        ret.url = ruleURI(ruleId).url
-      }
+      ret.location.position = range
 
       const ruleAppendix = showRule ? ` (${ruleId || 'Fatal'})` : ''
       ret.excerpt = `${message}${ruleAppendix}`

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -270,12 +270,6 @@ export async function processESLintMessages(response, textEditor, showRule, work
         ret.solutions = [linterFix]
       }
     } catch (err) {
-      if (!err.message.startsWith('Line number ') &&
-        !err.message.startsWith('Column start ')
-      ) {
-        // This isn't an invalid point error from `generateRange`, re-throw it
-        throw err
-      }
       ret = await generateInvalidTrace({
         msgLine,
         msgCol,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -133,7 +133,7 @@ export async function generateDebugString(worker) {
   return details.join('\n')
 }
 
-export async function handleError(textEditor, error) {
+export function handleError(textEditor, error) {
   const { stack, message } = error
   // Only show the first line of the message as the excerpt
   const excerpt = `Error while running ESLint: ${message.split('\n')[0]}.`


### PR DESCRIPTION
## Handle errors as a lint message

Translate all errors coming from ESLint into a lint message instead of throwing them out to be caught by Linter's generic error catching mechanism. This allows us to present them in a much cleaner manner and
gives the user immediate feedback on what is going wrong.

Also includes several cleanups related to error handling to get a more unified experience with errors.

### Before

Errors were only shown as an Atom error notification from Linter's generic catch-all:
![image](https://user-images.githubusercontent.com/427137/30517393-610b93a0-9b12-11e7-9499-b064bab893f4.png)
Repeated lint requests would spam the message on the user's screen, providing a rather poor experience.

### After

Errors coming from ESLint will show as a message in Linter, with the expandable message details showing the full stack trace:
Linter message:
![image](https://user-images.githubusercontent.com/427137/30517385-20354f56-9b12-11e7-901a-065e83ac7646.png)
Full details:
![image](https://user-images.githubusercontent.com/427137/30517381-0a463d22-9b12-11e7-83ef-e17828b861d2.png)

Fixes #387.