### PR TITLE
Allow multiple rule directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,14 @@
       "type": "string",
       "default": ""
     },
-    "eslintRulesDir": {
-      "title": "ESLint Rules Dir",
-      "description": "Specify a directory for ESLint to load rules from",
-      "type": "string",
-      "default": ""
+    "eslintRulesDirs": {
+      "title": "ESLint Rules Directories",
+      "description": "Specify a comma separated list of directories for ESLint to load rules from.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
     },
     "disableEslintIgnore": {
       "title": "Don't use .eslintignore files",

--- a/src/main.js
+++ b/src/main.js
@@ -62,6 +62,20 @@ module.exports = {
     this.subscriptions = new CompositeDisposable()
     this.worker = null
 
+    /**
+     * FIXME: Deprecated eslintRulesDir{String} option in favor of
+     * eslintRulesDirs{Array<String>}. Remove in the next major release,
+     * in v8.5.0, or after 2018-04.
+     */
+    const oldRulesdir = atom.config.get('linter-eslint.eslintRulesDir')
+    if (oldRulesdir) {
+      const rulesDirs = atom.config.get('linter-eslint.eslintRulesDirs')
+      if (rulesDirs.length === 0) {
+        atom.config.set('linter-eslint.eslintRulesDirs', [oldRulesdir])
+      }
+      atom.config.unset('linter-eslint.eslintRulesDir')
+    }
+
     const embeddedScope = 'source.js.embedded.html'
     this.subscriptions.add(atom.config.observe(
       'linter-eslint.lintHtmlFiles',

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -169,15 +169,13 @@ export function getCLIEngineOptions(type, config, rules, filePath, fileDir, give
     cliEngineConfig.ignorePath = ignoreFile
   }
 
-  if (config.eslintRulesDir) {
-    let rulesDir = cleanPath(config.eslintRulesDir)
+  cliEngineConfig.rulePaths = config.eslintRulesDirs.map((path) => {
+    const rulesDir = cleanPath(path)
     if (!Path.isAbsolute(rulesDir)) {
-      rulesDir = findCached(fileDir, rulesDir)
+      return findCached(fileDir, rulesDir)
     }
-    if (rulesDir) {
-      cliEngineConfig.rulePaths = [rulesDir]
-    }
-  }
+    return rulesDir
+  }).filter(path => path)
 
   if (givenConfigPath === null && config.eslintrcPath) {
     // If we didn't find a configuration use the fallback from the settings


### PR DESCRIPTION
Replace the `eslintRulesDir` option with a new `eslintRulesDirs` option that is an Array of directories that are passed to ESLint.

Fixes #321.