### PR TITLE
Check for remote files

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -143,6 +143,9 @@ export async function generateDebugString(worker) {
  * Turn the given options into a Linter message array
  * @param  {TextEditor} textEditor The TextEditor to use to build the message
  * @param  {Object} options    The parameters used to fill in the message
+ * @param  {string} [options.severity='error'] Can be one of: 'error', 'warning', 'info'
+ * @param  {string} [options.excerpt=''] Short text to use in the message
+ * @param  {string|Function} [options.description] Used to provide additional information
  * @return {Array}            Message to user generated from the parameters
  */
 export function generateUserMessage(textEditor, options) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -139,19 +139,42 @@ export async function generateDebugString(worker) {
   return details.join('\n')
 }
 
-export function handleError(textEditor, error) {
-  const { stack, message } = error
-  // Only show the first line of the message as the excerpt
-  const excerpt = `Error while running ESLint: ${message.split('\n')[0]}.`
+/**
+ * Turn the given options into a Linter message array
+ * @param  {TextEditor} textEditor The TextEditor to use to build the message
+ * @param  {Object} options    The parameters used to fill in the message
+ * @return {Array}            Message to user generated from the parameters
+ */
+export function generateUserMessage(textEditor, options) {
+  const {
+    severity = 'error',
+    excerpt = '',
+    description,
+  } = options
   return [{
-    severity: 'error',
+    severity,
     excerpt,
-    description: `<div style="white-space: pre-wrap">${message}\n<hr />${stack}</div>`,
+    description,
     location: {
       file: textEditor.getPath(),
       position: generateRange(textEditor),
     },
   }]
+}
+
+/**
+ * Generates a message to the user in order to nicely display the Error being
+ * thrown instead of depending on generic error handling.
+ * @param  {TextEditor} textEditor The TextEditor to use to build the message
+ * @param  {Error} error      Error to generate a message for
+ * @return {Array}            Message to user generated from the Error
+ */
+export function handleError(textEditor, error) {
+  const { stack, message } = error
+  // Only show the first line of the message as the excerpt
+  const excerpt = `Error while running ESLint: ${message.split('\n')[0]}.`
+  const description = `<div style="white-space: pre-wrap">${message}\n<hr />${stack}</div>`
+  return generateUserMessage(textEditor, { severity: 'error', excerpt, description })
 }
 
 const generateInvalidTrace = async ({

--- a/src/main.js
+++ b/src/main.js
@@ -188,11 +188,26 @@ module.exports = {
       scope: 'file',
       lintsOnChange: true,
       lint: async (textEditor) => {
-        const text = textEditor.getText()
-        if (text.length === 0) {
-          return []
+        if (!atom.workspace.isTextEditor(textEditor)) {
+          // If we somehow get fed an invalid TextEditor just immediately return
+          return null
         }
+
         const filePath = textEditor.getPath()
+        if (!filePath) {
+          // The editor currently has no path, we can't report messages back to
+          // Linter so just return null
+          return null
+        }
+
+        if (filePath.includes('://')) {
+          // If the path is a URL (Nuclide remote file) return a message
+          // telling the user we are unable to work on remote files.
+          const message = 'Remote file open, impossible to run ESLint.'
+          helpers.handleError(textEditor, new Error(message))
+        }
+
+        const text = textEditor.getText()
 
         if (!helpers) {
           helpers = require('./helpers')

--- a/src/main.js
+++ b/src/main.js
@@ -203,8 +203,10 @@ module.exports = {
         if (filePath.includes('://')) {
           // If the path is a URL (Nuclide remote file) return a message
           // telling the user we are unable to work on remote files.
-          const message = 'Remote file open, impossible to run ESLint.'
-          helpers.handleError(textEditor, new Error(message))
+          return helpers.generateUserMessage(textEditor, {
+            severity: 'warning',
+            excerpt: 'Remote file open, linter-eslint is disabled for this file.',
+          })
         }
 
         const text = textEditor.getText()


### PR DESCRIPTION
Add several sanity checks before moving on to attempting to lint the file:

* Check that the `TextEditor` is valid
* Check that the path for the file is not empty
* Check that the path isn't a remote path

If a remote path is found, show a message to the user that linting isn't possible.

Blocked on #1015 as it uses the Error handling functionality introduced in that branch. Just putting this up here so it can get reviewed.

Fixes #594.