### PR TITLE
Add option to silence fixable rules while typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,12 @@
       "items": {
         "type": "string"
       }
+    },
+    "ignoreFixableRulesWhileTyping": {
+      "title": "Ignore fixable rules while typing",
+      "description": "Have the linter ignore all fixable rules during linting when editing a document. The list is automatically updated on each lint job, and requires at least one run to be populated.",
+      "type": "boolean",
+      "default": false
     }
   },
   "scripts": {

--- a/spec/fixtures/modified-ignore-rule/.eslintrc.js
+++ b/spec/fixtures/modified-ignore-rule/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   root: true,
   rules: {
+    'no-console': 'error',
     'no-trailing-spaces': 'error'
   }
 }

--- a/spec/fixtures/modified-ignore-rule/foo-space.js
+++ b/spec/fixtures/modified-ignore-rule/foo-space.js
@@ -1,1 +1,2 @@
+console.log("I'm unfixable, yay!");
 foo = 42; 

--- a/spec/fixtures/modified-ignore-rule/foo.js
+++ b/spec/fixtures/modified-ignore-rule/foo.js
@@ -1,1 +1,2 @@
+console.log("I'm unfixable, yay!");
 foo = 42;

--- a/spec/fixtures/plugin-import/.eslintrc.js
+++ b/spec/fixtures/plugin-import/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  // root: true,
+  plugins: [
+    'import'
+  ],
+  rules: {
+    'import/newline-after-import': 'error'
+  }
+}

--- a/spec/fixtures/plugin-import/life.js
+++ b/spec/fixtures/plugin-import/life.js
@@ -1,0 +1,3 @@
+import { meaning } from './meaning'
+
+console.log(`The meaning of life is ${meaning}.`)

--- a/spec/fixtures/plugin-import/meaning.js
+++ b/spec/fixtures/plugin-import/meaning.js
@@ -1,0 +1,1 @@
+export const meaning = 42;

--- a/src/worker.js
+++ b/src/worker.js
@@ -15,7 +15,12 @@ let sendRules = false
 function updateFixableRules(eslint) {
   const { Linter } = eslint
   const linter = new Linter()
-  const currentRules = new Set(linter.getRules().keys())
+  const currentRules = new Set()
+  linter.getRules().forEach((props, rule) => {
+    if (Object.prototype.hasOwnProperty.call(props.meta, 'fixable')) {
+      currentRules.add(rule)
+    }
+  })
 
   sendRules = false
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -12,9 +12,7 @@ process.title = 'linter-eslint helper'
 const fixableRules = new Set()
 let sendRules = false
 
-function updateFixableRules(eslint) {
-  const { Linter } = eslint
-  const linter = new Linter()
+function updateFixableRules(linter) {
   const currentRules = new Set()
   linter.getRules().forEach((props, rule) => {
     if (Object.prototype.hasOwnProperty.call(props.meta, 'fixable')) {
@@ -45,7 +43,7 @@ function updateFixableRules(eslint) {
 function lintJob({ cliEngineOptions, contents, eslint, filePath }) {
   const cliEngine = new eslint.CLIEngine(cliEngineOptions)
   const report = cliEngine.executeOnText(contents, filePath)
-  updateFixableRules(eslint)
+  updateFixableRules(cliEngine.linter)
   return report
 }
 


### PR DESCRIPTION
Add an option that silences fixable rules while typing. The list of fixable rules is populated from ESLint itself, and only sent back to the main package code when it updates to reduce message size. This means that this will only start silencing rules after the first lint rule. Since a lint is triggered on open by default this _should_ be largely transparent to the user.

Fixes #894.