### PR TITLE
Fix deprecation warning in Atom v1.21.0

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -155,11 +155,9 @@ module.exports = {
           // Compares the private component property of the active TextEditor
           //   against the components of the elements
           const evtIsActiveEditor = evt.path.some(elem =>
-            // Atom v1.19.0
+            // Atom v1.19.0+
             (elem.component && activeEditor.component &&
-              elem.component === activeEditor.component) ||
-            // Atom v1.18.0
-            (activeEditor.editorElement === elem))
+              elem.component === activeEditor.component))
           // Only show if it was the active editor and it is a valid scope
           return evtIsActiveEditor && validScope(activeEditor)
         }


### PR DESCRIPTION
Atom has started showing a deprecation warning for the Atom v1.18.0 style check done for the context menu. Remove this check making the context menu now only show on Atom v1.19.0 and above.

![image](https://user-images.githubusercontent.com/427137/30519389-3306f62e-9b4a-11e7-91f5-db1568aa606b.png)