### PR TITLE
Don't attempt to process fixable rules on ESLint v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     },
     "ignoreFixableRulesWhileTyping": {
       "title": "Ignore fixable rules while typing",
-      "description": "Have the linter ignore all fixable rules during linting when editing a document. The list is automatically updated on each lint job, and requires at least one run to be populated.",
+      "description": "Have the linter ignore all fixable rules during linting when editing a document. The list is automatically updated on each lint job, and requires at least one run to be populated. Only supported when using ESLint v4+.",
       "type": "boolean",
       "default": false
     }

--- a/src/worker.js
+++ b/src/worker.js
@@ -21,6 +21,11 @@ let sendRules = false
  * @return {void}
  */
 function updateFixableRules(linter) {
+  if (linter === undefined) {
+    // ESLint < v4 doesn't support this property
+    return
+  }
+
   // Build a set of fixable rules based on the rules loaded in the provided linter
   const currentRules = new Set()
   linter.getRules().forEach((props, rule) => {


### PR DESCRIPTION
ESLint below v4 doesn't support the necessary version of the ESLint `Linter` API to allow grabbing the fixable rules. When running with an ancient version of ESLint simply don't process fixable rules.

Fixes #1021.