### PR TITLE
Verify that a rule has a meta property before accessing

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -29,7 +29,10 @@ function updateFixableRules(linter) {
   // Build a set of fixable rules based on the rules loaded in the provided linter
   const currentRules = new Set()
   linter.getRules().forEach((props, rule) => {
-    if (Object.prototype.hasOwnProperty.call(props.meta, 'fixable')) {
+    if (
+      Object.prototype.hasOwnProperty.call(props, 'meta') &&
+      Object.prototype.hasOwnProperty.call(props.meta, 'fixable')
+    ) {
       currentRules.add(rule)
     }
   })


### PR DESCRIPTION
Verify that a rule has a `meta` property before attempting to access it to see if the rule is fixable or not.

Fixes #1023.