### PR TITLE
Remove definition of warnIgnored in CLIEngine options

### DIFF
--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -160,7 +160,6 @@ export function getCLIEngineOptions(type, config, rules, filePath, fileDir, give
   const cliEngineConfig = {
     rules,
     ignore: !config.disableEslintIgnore,
-    warnIgnored: false,
     fix: type === 'fix'
   }
 


### PR DESCRIPTION
This flag has no meaning to the `CLIEngine` constructor, it is only valid as an optional third argument to `executeOnText`. When this was mistakenly added in https://github.com/AtomLinter/linter-eslint/pull/915 this was missed. Luckily the problem it was meant to solve was accepted as a bug against ESLint itself and fixed there which is why this wasn't caught earlier.