### PR TITLE
Don't return promise until makeFixes completes

### DIFF
--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -218,9 +218,10 @@ describe('The eslint provider for Linter', () => {
 
     it('will not give warnings when autofixing the file', async () => {
       const editor = await atom.workspace.open(paths.ignored)
-      atom.commands.dispatch(atom.views.getView(editor), 'linter-eslint:fix-file')
       const expectedMessage = 'Linter-ESLint: Fix complete.'
-      const notification = await getNotification(expectedMessage)
+      const notificationPromise = getNotification(expectedMessage)
+      atom.commands.dispatch(atom.views.getView(editor), 'linter-eslint:fix-file')
+      const notification = await notificationPromise
 
       expect(notification.getMessage()).toBe(expectedMessage)
     })
@@ -474,16 +475,18 @@ describe('The eslint provider for Linter', () => {
     })
 
     it('shows an info notification', async () => {
+      const notificationPromise = getNotification(expectedMessage)
       atom.commands.dispatch(atom.views.getView(editor), 'linter-eslint:debug')
-      const notification = await getNotification(expectedMessage)
+      const notification = await notificationPromise
 
       expect(notification.getMessage()).toBe(expectedMessage)
       expect(notification.getType()).toEqual('info')
     })
 
     it('includes debugging information in the details', async () => {
+      const notificationPromise = getNotification(expectedMessage)
       atom.commands.dispatch(atom.views.getView(editor), 'linter-eslint:debug')
-      const notification = await getNotification(expectedMessage)
+      const notification = await notificationPromise
       const detail = notification.getDetail()
 
       expect(detail.includes(`Atom version: ${atom.getVersion()}`)).toBe(true)

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -84,23 +84,23 @@ async function getNotification(expectedMessage) {
 }
 
 async function makeFixes(textEditor) {
-  return new Promise(async (resolve) => {
+  const editorReloaded = new Promise((resolve) => {
     // Subscribe to the file reload event
-    const editorReloadSub = textEditor.getBuffer().onDidReload(async () => {
-      editorReloadSub.dispose()
-      // File has been reloaded in Atom, notification checking will happen
-      // async either way, but should already be finished at this point
+    const reloadSubscription = textEditor.getBuffer().onDidReload(() => {
+      reloadSubscription.dispose()
       resolve()
     })
-
-    // Now that all the required subscriptions are active, send off a fix request
-    atom.commands.dispatch(atom.views.getView(textEditor), 'linter-eslint:fix-file')
-    const expectedMessage = 'Linter-ESLint: Fix complete.'
-    const notification = await getNotification(expectedMessage)
-
-    expect(notification.getMessage()).toBe(expectedMessage)
-    expect(notification.getType()).toBe('success')
   })
+
+  // Now that subscription is active, send off a fix request
+  atom.commands.dispatch(atom.views.getView(textEditor), 'linter-eslint:fix-file')
+  const expectedMessage = 'Linter-ESLint: Fix complete.'
+  const notification = await getNotification(expectedMessage)
+
+  expect(notification.getMessage()).toBe(expectedMessage)
+  expect(notification.getType()).toBe('success')
+
+  return editorReloaded
 }
 
 describe('The eslint provider for Linter', () => {


### PR DESCRIPTION
The makeFixes function is now properly determinent, as a consumer cannot
receive a resolved promise before all lines of makeFixes have executed.
This might (appears to so far) resolve problems with flaky specs.