### PR TITLE
Handle worker crashes

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,8 +43,10 @@ export async function sendJob(worker, config) {
   config.emitKey = cryptoRandomString(10)
 
   return new Promise((resolve, reject) => {
-    const errSub = worker.on('task:error', (...err) => {
-      const [msg, stack] = err
+    // All worker errors are caught and re-emitted along with their associated
+    // emitKey, so that we do not create multiple listeners for the same
+    // 'task:error' event
+    const errSub = worker.on(`workerError:${config.emitKey}`, ({ msg, stack }) => {
       // Re-throw errors from the task
       const error = new Error(msg)
       // Set the stack to the one given to us by the worker

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,6 +49,9 @@ export async function sendJob(worker, config) {
       const error = new Error(msg)
       // Set the stack to the one given to us by the worker
       error.stack = stack
+      errSub.dispose()
+      // eslint-disable-next-line no-use-before-define
+      responseSub.dispose()
       reject(error)
     })
     const responseSub = worker.on(config.emitKey, (data) => {
@@ -60,6 +63,8 @@ export async function sendJob(worker, config) {
     try {
       worker.send(config)
     } catch (e) {
+      errSub.dispose()
+      responseSub.dispose()
       console.error(e)
     }
   })

--- a/src/worker.js
+++ b/src/worker.js
@@ -85,10 +85,10 @@ module.exports = async () => {
   process.on('message', (jobConfig) => {
     // We catch all worker errors so that we can create a separate error emitter
     // for each emitKey, rather than adding multiple listeners for `task:error`
+    const {
+      contents, type, config, filePath, projectPath, rules, emitKey
+    } = jobConfig
     try {
-      const {
-        contents, type, config, filePath, projectPath, rules, emitKey
-      } = jobConfig
       if (config.disableFSCache) {
         FindCache.clear()
       }
@@ -124,7 +124,7 @@ module.exports = async () => {
       }
       emit(emitKey, response)
     } catch (workerErr) {
-      emit(`workerError:${jobConfig.emitKey}`, { msg: workerErr.message, stack: workerErr.stack })
+      emit(`workerError:${emitKey}`, { msg: workerErr.message, stack: workerErr.stack })
     }
   })
 }


### PR DESCRIPTION
Refs #925 #927 #930 #1059

This is an attempt to mitigate some of the problems being experienced in the referenced issues, whereby linter-eslint crashes/hangs with a high memory usage.

I was unable to determine the exact cause of workers dying, but this PR does a few things to try to minimize the crashes and memory usage, as well as allowing linter-eslint to recover from a crashed worker.  In one of my projects, I was able to reliably reproduce the crashes, usually within a few seconds of opening a file.  Using this branch, linter-eslint has now become usable for me again, albeit during a crash it still takes a few seconds to recover and start working again, so I don't consider this a complete solution.

I think the main challenge we are facing is that the Task api from Atom is not intended to be used as a long-running task, which is what we need because starting up a lint job can take a second or two.  Maybe we can find another, more reliable approach in the future, but hopefully this PR will at least make `linter-eslint` usable again for those folks currently stuck on the old version.