### PR TITLE
Check if the rule properties exist before checking for meta

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -29,7 +29,7 @@ export default class Rules {
    */
   getFixableRules() {
     return Array.from(this[rules]).reduce((fixable, [rule, props]) => {
-      if (props.meta && props.meta.fixable) {
+      if (props && props.meta && props.meta.fixable) {
         return [...fixable, rule]
       }
       return fixable


### PR DESCRIPTION
Ensure that the rule actually has properties before attempting to check the `meta` property of them.