### PR TITLE
Update: Add ramda, fast-deep-equal, generic utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1814,6 +1814,11 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,9 @@
     "crypto-random-string": "^1.0.0",
     "eslint": "^4.9.0",
     "eslint-rule-documentation": "^1.0.18",
+    "fast-deep-equal": "^1.0.0",
     "fs-plus": "^3.0.1",
+    "ramda": "^0.25.0",
     "resolve-env": "^1.0.0",
     "user-home": "^2.0.0"
   },

--- a/spec/f-utils/deep-diff-dict-spec.js
+++ b/spec/f-utils/deep-diff-dict-spec.js
@@ -1,7 +1,6 @@
 'use babel'
 
 // eslint-disable-next-line no-unused-vars
-import 'jasmine-fix'
 import diff from '../../src/f-utils/deep-diff-dict'
 
 

--- a/spec/f-utils/deep-diff-dict-spec.js
+++ b/spec/f-utils/deep-diff-dict-spec.js
@@ -1,0 +1,52 @@
+'use babel'
+
+// eslint-disable-next-line no-unused-vars
+import 'jasmine-fix'
+import diff from '../../src/f-utils/deep-diff-dict'
+
+
+describe('deepDiffDict', () => {
+  it('finds added props', () => {
+    const A = { prop1: { prop: 'value' } }
+    const B = {
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' }
+    }
+    const { added } = diff(A, B)
+    expect(added).toEqual({ prop2: { prop: 'value' } })
+  })
+
+  it('finds removed props', () => {
+    const A = {
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' }
+    }
+    const B = { prop2: { prop: 'value' } }
+
+    const { removed } = diff(A, B)
+    expect(removed).toEqual({ prop1: { prop: 'value' } })
+  })
+
+  it('finds modified props', () => {
+    const A = {
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' },
+      prop3: { prop: 'value' }
+    }
+    const B = {
+      prop1: { differentProp: 'value' },
+      prop2: { prop: 'different value' }
+    }
+
+    const { added, removed } = diff(A, B)
+    expect(added).toEqual({
+      prop1: { differentProp: 'value' },
+      prop2: { prop: 'different value' }
+    })
+    expect(removed).toEqual({
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' },
+      prop3: { prop: 'value' }
+    })
+  })
+})

--- a/spec/f-utils/f-utils-spec.js
+++ b/spec/f-utils/f-utils-spec.js
@@ -1,0 +1,140 @@
+'use babel'
+
+// eslint-disable-next-line no-unused-vars
+import 'jasmine-fix'
+import {
+  fromMapToObj,
+  fromObjToMap,
+  isNotNil,
+  deepProp,
+  keyedFilter,
+  keyedMap,
+} from '../../src/f-utils'
+
+
+describe('fromMapToObj', () => {
+  it('transforms a Map to an Object dictionary', () => {
+    const map = new Map([['a', 'some string'], ['b', 10], ['c', {}]])
+    const expected = { a: 'some string', b: 10, c: {} }
+    expect(fromMapToObj(map)).toEqual(expected)
+  })
+
+  it('returns empty object if given empty map', () => {
+    const map = new Map()
+    const expected = {}
+    expect(fromMapToObj(map)).toEqual(expected)
+  })
+})
+
+
+describe('fromObjToMap', () => {
+  it('transforms an Object dictionary to a Map', () => {
+    const obj = { a: 'some string', b: 25, c: {} }
+    const expected = new Map([['a', 'some string'], ['b', 25], ['c', {}]])
+    expect(fromObjToMap(obj)).toEqual(expected)
+  })
+
+  it('returns empty map if given empty object', () => {
+    const obj = {}
+    const expected = new Map()
+    expect(fromObjToMap(obj)).toEqual(expected)
+  })
+})
+
+
+describe('isNotNil', () => {
+  it('returns false for nil values', () => {
+    expect(isNotNil(undefined)).toBe(false)
+    expect(isNotNil(null)).toBe(false)
+  })
+
+  it('returns true for non-nil values', () => {
+    expect(isNotNil(true)).toBe(true)
+    expect(isNotNil(19)).toBe(true)
+    expect(isNotNil({})).toBe(true)
+    expect(isNotNil(new Map())).toBe(true)
+  })
+})
+
+
+describe('deepProp', () => {
+  it('finds a shallow prop', () => {
+    const obj = { a: '10', b: 0 }
+    expect(deepProp('a', obj)).toBe('10')
+  })
+
+  it('finds a deep prop', () => {
+    const obj = { a: { b: { c: { d: { e: { f: -1, g: 42 } } } } } }
+    expect(deepProp('a.b.c.d.e.g', obj)).toBe(42)
+  })
+
+  it('does not choke on falsy values', () => {
+    const obj = { a: { b: null } }
+    expect(deepProp('a.b', obj)).toBe(null)
+  })
+
+  it('fails gracefully', () => {
+    const obj = { a: { b: 'value' } }
+    expect(deepProp('some.unknown.prop.path', obj)).toBe(undefined)
+  })
+})
+
+
+describe('keyedFilter', () => {
+  it("adds index and original array to predicate's params", () => {
+    const array = [1, 2, 3]
+    let i = 0
+    const predicate = (value, index, arr) => {
+      expect(index).toBe(i)
+      expect(arr).toEqual(array)
+      i += 1
+      return value > 2
+    }
+    const result = keyedFilter(predicate, array)
+    expect(result).toEqual([3])
+  })
+
+  it("adds property key and original object to predicate's params", () => {
+    const keys = ['a', 'b', 'c']
+    const object = { a: 1, b: 2, c: 3 }
+    let i = 0
+    const predicate = (value, key, obj) => {
+      expect(keys.indexOf(key)).toBe(i)
+      expect(obj).toEqual(object)
+      i += 1
+      return key > 'b'
+    }
+    const result = keyedFilter(predicate, object)
+    expect(result).toEqual({ c: 3 })
+  })
+})
+
+
+describe('keyedMap', () => {
+  it("adds index and original array to transformer's params", () => {
+    const array = [1, 2, 3]
+    let i = 0
+    const transformer = (value, index, arr) => {
+      expect(index).toBe(i)
+      expect(arr).toEqual(array)
+      i += 1
+      return value + 5
+    }
+    const result = keyedMap(transformer, array)
+    expect(result).toEqual([6, 7, 8])
+  })
+
+  it("adds property key and original object to transformer's params", () => {
+    const keys = ['a', 'b', 'c']
+    const object = { a: 1, b: 2, c: 3 }
+    let i = 0
+    const transformer = (value, key, obj) => {
+      expect(keys.indexOf(key)).toBe(i)
+      expect(obj).toEqual(object)
+      i += 1
+      return key
+    }
+    const result = keyedMap(transformer, object)
+    expect(result).toEqual({ a: 'a', b: 'b', c: 'c' })
+  })
+})

--- a/spec/f-utils/f-utils-spec.js
+++ b/spec/f-utils/f-utils-spec.js
@@ -1,7 +1,6 @@
 'use babel'
 
 // eslint-disable-next-line no-unused-vars
-import 'jasmine-fix'
 import {
   fromMapToObj,
   fromObjToMap,

--- a/src/f-utils/deep-diff-dict.js
+++ b/src/f-utils/deep-diff-dict.js
@@ -1,0 +1,32 @@
+'use babel'
+
+import deepEq from 'fast-deep-equal'
+
+const { keys } = Object
+
+/** ********************
+ * deepDiffDictionary *
+ ********************* */
+
+// Diff 2 object dictionaries with deep comparison
+//
+// deepDiffDictionary :: Object a -> Object b -> Object c
+const deepDiffDictionary = (a, b) => {
+  const uniqueKeys = Array.from(new Set([
+    ...keys(a),
+    ...keys(b)
+  ]))
+
+  /* eslint-disable no-param-reassign */
+  return uniqueKeys.reduce(({ added, removed }, k) => {
+    if (a[k] === undefined) added[k] = b[k]
+    else if (b[k] === undefined) removed[k] = a[k]
+    else if (deepEq(a[k], b[k]) === false) {
+      added[k] = b[k]
+      removed[k] = a[k]
+    }
+    return { added, removed }
+  }, { added: {}, removed: {} })
+}
+
+export default deepDiffDictionary

--- a/src/f-utils/index.js
+++ b/src/f-utils/index.js
@@ -2,8 +2,6 @@
 
 import r from '../f-utils/mini-ramda'
 
-// random comment to test out `hub` behavior
-
 /** *************
  * Typecasting *
  ************** */

--- a/src/f-utils/index.js
+++ b/src/f-utils/index.js
@@ -1,0 +1,75 @@
+'use babel'
+
+import r from '../f-utils/mini-ramda'
+
+/** *************
+ * Typecasting *
+ ************** */
+
+// fromMapToObj :: Map a -> Object a
+export const fromMapToObj = m => r.fromPairs([...m])
+
+// fromObjToMap :: Object a -> Map a
+export const fromObjToMap = o => new Map(r.toPairs(o))
+
+
+/** ************
+ * Predicates *
+ ************* */
+
+// False if parameter is null or undefined, else true
+//
+// isNotNil :: Any -> Boolean
+export const isNotNil = r.pipe(r.isNil, r.not)
+
+// True if parameter is undefined, else false
+//
+// isUndef :: Any -> Boolean
+export const isUndef = x => x === undefined
+
+
+/** *****************
+ * Extracting data *
+ ****************** */
+
+// Value of a nested property if it exists
+//   * usage: deepProp('a.b.c.d', obj) == obj.a.b.c.d
+//
+// deepProp :: String -> Object -> Any
+export const deepProp = r.curry((k, o) => r.path(k.split('.'), o))
+
+
+/** *******************************
+ * Modifying callback signatures *
+ ******************************** */
+
+// Filter object properties with property keys passed
+// as second argument to predicate function.
+//
+// keyedFilter :: (a, String|Number) -> Object<a> -> Object<a>
+export const keyedFilter = r.curry((f, o) => {
+  if (Array.isArray(o)) {
+    return r.addIndex(r.filter)(f, o)
+  }
+  return Object.keys(o)
+    .reduce((filtered, k) => ({
+      ...filtered,
+      ...(f(o[k], k, o) ? { [k]: o[k] } : null)
+    }), {})
+})
+
+// Map over object properties with property keys passed
+// as second argument to transforming function.
+//
+// keyedMap :: (a, String|Number) -> Object<a> -> Object<b>
+
+export const keyedMap = r.curry((f, o) => {
+  if (Array.isArray(o)) {
+    return r.addIndex(r.map)(f, o)
+  }
+  return Object.keys(o)
+    .reduce((mapped, k) => ({
+      ...mapped,
+      [k]: f(o[k], k, o)
+    }), {})
+})

--- a/src/f-utils/index.js
+++ b/src/f-utils/index.js
@@ -2,6 +2,8 @@
 
 import r from '../f-utils/mini-ramda'
 
+// random comment to test out `hub` behavior
+
 /** *************
  * Typecasting *
  ************** */

--- a/src/f-utils/mini-ramda.js
+++ b/src/f-utils/mini-ramda.js
@@ -1,0 +1,53 @@
+'use babel'
+
+// Curated list of ramda functions actually in use.
+//
+// This provides for importing these functions on a namespace
+// without importing the entire library.
+//
+
+
+// From standpoint of category theory, compose is preferable construct
+// over pipe. But the top-down flow of pipe may reduce learning curve
+// for contributors less familiar with compositional style.
+//
+import pipe from 'ramda/src/pipe'
+
+import addIndex from 'ramda/src/addIndex'
+import apply from 'ramda/src/apply'
+import clone from 'ramda/src/clone'
+import curry from 'ramda/src/curry'
+import filter from 'ramda/src/filter'
+import flip from 'ramda/src/flip'
+import fromPairs from 'ramda/src/fromPairs'
+import identity from 'ramda/src/identity'
+import isNil from 'ramda/src/isNil'
+import map from 'ramda/src/map'
+import not from 'ramda/src/not'
+import path from 'ramda/src/path'
+import pluck from 'ramda/src/pluck'
+import prop from 'ramda/src/prop'
+import reverse from 'ramda/src/reverse'
+import reduce from 'ramda/src/reduce'
+import toPairs from 'ramda/src/toPairs'
+
+export default {
+  addIndex,
+  apply,
+  clone,
+  curry,
+  filter,
+  flip,
+  fromPairs,
+  identity,
+  isNil,
+  map,
+  not,
+  path,
+  pipe,
+  pluck,
+  prop,
+  reverse,
+  reduce,
+  toPairs,
+}


### PR DESCRIPTION
Adds ramda dependency with a file to map small subset to a namespaced
    import. Adds fast-deep-equal. Adds several small generic functionaly
    utility functions with specs to verify their behavior. Anything in this
    commit not in use by the next planned release should be deleted until
    proven necessary.