### PR TITLE
Add 'javascript' scope by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
       "title": "List of scopes to run ESLint on, run `Editor: Log Cursor Scope` to determine the scopes for a file.",
       "type": "array",
       "default": [
+        "javascript",
         "source.js",
         "source.jsx",
         "source.js.jsx",


### PR DESCRIPTION
Everything appears to work as expected with experimental tree-sitter parser. This adds the new scope name to default scopes array.