### PR TITLE
Fix CI builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,9 +1040,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1",
@@ -1052,7 +1052,7 @@
         "eslint-import-resolver-node": "0.3.2",
         "eslint-module-utils": "2.1.1",
         "has": "1.0.1",
-        "lodash.cond": "4.5.2",
+        "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "read-pkg-up": "2.0.0"
       },
@@ -1555,12 +1555,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
-      "dev": true
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -1638,7 +1632,7 @@
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "number-is-nan": {
@@ -2082,24 +2076,35 @@
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
     "sprintf-js": {
@@ -2280,13 +2285,13 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   },
   "devDependencies": {
     "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.9.0",
     "jasmine-fix": "^1.3.1",
     "rimraf": "^2.6.2"
   },

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -192,12 +192,12 @@ describe('The eslint provider for Linter', () => {
       const editor = await atom.workspace.open(paths.badImport)
       const messages = await lint(editor)
       const expected = "Unable to resolve path to module '../nonexistent'. (import/no-unresolved)"
-      const expectedUrl = 'https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md'
+      const expectedUrlRegEx = /https[\S]+eslint-plugin-import[\S]+no-unresolved.md/
 
       expect(messages.length).toBe(1)
       expect(messages[0].severity).toBe('error')
       expect(messages[0].excerpt).toBe(expected)
-      expect(messages[0].url).toBe(expectedUrl)
+      expect(messages[0].url).toMatch(expectedUrlRegEx)
       expect(messages[0].location.file).toBe(paths.badImport)
       expect(messages[0].location.position).toEqual([[0, 24], [0, 40]])
       expect(messages[0].solutions).not.toBeDefined()
@@ -455,7 +455,8 @@ describe('The eslint provider for Linter', () => {
       const messages = await lint(editor)
       expect(messages.length).toBe(1)
       expect(messages[0].severity).toBe('error')
-      expect(messages[0].excerpt).toBe('Expected empty line after import statement not followed by another import. (import/newline-after-import)')
+      expect(messages[0].excerpt).toBe('Expected 1 empty line after import ' +
+        'statement not followed by another import. (import/newline-after-import)')
 
       // Enable the option under test
       // NOTE: Depends on mport/newline-after-import rule being marked as fixable
@@ -655,7 +656,7 @@ describe('The eslint provider for Linter', () => {
   })
 
   describe('handles the Show Rule ID in Messages option', () => {
-    const expectedUrl = 'https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md'
+    const expectedUrlRegEx = /https[\S]+eslint-plugin-import[\S]+no-unresolved.md/
 
     it('shows the rule ID when enabled', async () => {
       atom.config.set('linter-eslint.advanced.showRuleIdInMessage', true)
@@ -666,7 +667,7 @@ describe('The eslint provider for Linter', () => {
       expect(messages.length).toBe(1)
       expect(messages[0].severity).toBe('error')
       expect(messages[0].excerpt).toBe(expected)
-      expect(messages[0].url).toBe(expectedUrl)
+      expect(messages[0].url).toMatch(expectedUrlRegEx)
       expect(messages[0].location.file).toBe(paths.badImport)
       expect(messages[0].location.position).toEqual([[0, 24], [0, 40]])
       expect(messages[0].solutions).not.toBeDefined()
@@ -681,7 +682,7 @@ describe('The eslint provider for Linter', () => {
       expect(messages.length).toBe(1)
       expect(messages[0].severity).toBe('error')
       expect(messages[0].excerpt).toBe(expected)
-      expect(messages[0].url).toBe(expectedUrl)
+      expect(messages[0].url).toMatch(expectedUrlRegEx)
       expect(messages[0].location.file).toBe(paths.badImport)
       expect(messages[0].location.position).toEqual([[0, 24], [0, 40]])
       expect(messages[0].solutions).not.toBeDefined()


### PR DESCRIPTION
Update the version of `eslint-plugin-import` used internally in the specs to the one that is installed by `apm` (which ignores `package-lock.json` currently), also updates the specs to accommodate the changes in the latest version.