### PR TITLE
updating global linter as fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "title": "Global ESLint",
       "properties": {
         "useGlobalEslint": {
-          "title": "Use global ESLint installation",
+          "title": "Always use global ESLint installation",
           "description": "Make sure you have it in your $PATH",
           "type": "boolean",
           "default": false,

--- a/spec/worker-helpers-spec.js
+++ b/spec/worker-helpers-spec.js
@@ -62,14 +62,25 @@ describe('Worker Helpers', () => {
       expect(foundEslint.type).toEqual('global')
     })
 
-    it('falls back to the packaged eslint when no local eslint is found', () => {
-      const modulesDir = 'not/a/real/path'
-      const config = createConfig({ global: { useGlobalEslint: false } })
-      const foundEslint = Helpers.findESLintDirectory(modulesDir, config)
-      const expectedBundledPath = Path.join(__dirname, '..', 'node_modules', 'eslint')
-      expect(foundEslint.path).toEqual(expectedBundledPath)
-      expect(foundEslint.type).toEqual('bundled fallback')
-    })
+	it('falls back to the global eslint when no local eslint is found', () => {
+	  const modulesDir = 'not/a/real/path'
+	  const config = createConfig({ global: { useGlobalEslint: false, globalNodePath } })
+	  const foundEslint = Helpers.findESLintDirectory(modulesDir, config)
+	  const expectedEslintPath = process.platform === 'win32'
+        ? Path.join(globalNodePath, 'node_modules', 'eslint')
+        : Path.join(globalNodePath, 'lib', 'node_modules', 'eslint')
+	  expect(foundEslint.path).toEqual(expectedEslintPath)
+	  expect(foundEslint.type).toEqual('global')
+	})
+
+    // it('falls back to the packaged eslint when no local or global eslint is found', () => {
+    //   const modulesDir = 'not/a/real/path'
+    //   const config = createConfig({ global: { useGlobalEslint: false } })
+    //   const foundEslint = Helpers.findESLintDirectory(modulesDir, config)
+    //   const expectedBundledPath = Path.join(__dirname, '..', 'node_modules', 'eslint')
+    //   expect(foundEslint.path).toEqual(expectedBundledPath)
+    //   expect(foundEslint.type).toEqual('bundled fallback')
+    // })
   })
 
   describe('getESLintInstance && getESLintFromDirectory', () => {


### PR DESCRIPTION
reposting my comment from [issue #845](https://github.com/AtomLinter/linter-eslint/issues/845)

Definitely. My original thinking is to make it so useGlobalEslint remains as an option to supersede local eslint? Though that sounds like a terrible idea. I wonder if that check should be removed entirely, so as to not make it easy to jump over a local eslint — which is definitely a bad idea.

Currently I have:

if (localNodeModules && !useGlobalEslint) then locationType = 'advanced specified'; and eslintDir uses a ternary to determine relative or absolute path.
else if (!useGlobalEslint) then locationType = 'local project' and eslintDir is pulled from the modules.
if (!isDirectory(eslintDir)) then locationType = 'global' and eslintDir is resolved to global directory, with respect to OS.
if (isDirectory(eslintDir)) then return the object
else then `throw new Error('ESLint not found, please add a local eslint to this project or ensure the global Node path is set correctly.')
But I can change that to reflect the thinking above. I also altered worker helper tests accordingly, but two eslint provider tests are failing:

when a file is specified in an eslintIgnore key in package.json it will not give warnings when linting the file is throwing the wrong error
it errors when no config file is found is also throwing the wrong error