### PR TITLE
Revert "Add 'javascript' scope by default"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
       "title": "List of scopes to run ESLint on, run `Editor: Log Cursor Scope` to determine the scopes for a file.",
       "type": "array",
       "default": [
-        "javascript",
         "source.js",
         "source.jsx",
         "source.js.jsx",


### PR DESCRIPTION
This reverts commit 1f2186ce29ddc1e503f13ad4cd7e3c9425100dd5.

Tree sitter now uses the regular TextMate based scopes, so this is not required and could be confusing.