### PR TITLE
Pin Dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -912,9 +912,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.75.tgz",
-      "integrity": "sha512-nLo03Qpw++8R6BxDZL/B1c8SQvUe/htdgc5LWYHe5YotV2jVvRUMP5AlOmxOsyeOzgMiXrNln2mC05Ixz6vuUQ=="
+      "version": "1.3.76",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.76.tgz",
+      "integrity": "sha512-qKQQzjRqpTqiVV7fP0DZRqndQFkzzp5knBvNkqdNIKd7Of/+d9tvNVtY3ffSDUD5UrMepe7IOmBflugDPhPNtA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1023,9 +1023,9 @@
           }
         },
         "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }

--- a/package.json
+++ b/package.json
@@ -162,17 +162,17 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "atom-babel6-transpiler": "^1.1.3",
-    "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.6.0",
-    "babel-preset-env": "^1.6.1",
-    "consistent-path": "^2.0.1",
-    "crypto-random-string": "^1.0.0",
-    "eslint": "^4.9.0",
-    "eslint-rule-documentation": "^1.0.18",
-    "fs-plus": "^3.0.1",
-    "resolve-env": "^1.0.0",
-    "user-home": "^2.0.0"
+    "atom-babel6-transpiler": "1.2.0",
+    "atom-linter": "10.0.0",
+    "atom-package-deps": "4.6.2",
+    "babel-preset-env": "1.7.0",
+    "consistent-path": "2.0.3",
+    "crypto-random-string": "1.0.0",
+    "eslint": "4.19.1",
+    "eslint-rule-documentation": "1.0.21",
+    "fs-plus": "3.0.2",
+    "resolve-env": "1.0.0",
+    "user-home": "2.0.0"
   },
   "devDependencies": {
     "eslint-config-airbnb-base": "13.1.0",


### PR DESCRIPTION
Pin the version of the dependencies that would have been installed via the old ranges if the `package-lock.json` wasn't present. Future updates to dependencies will ensure the `package-lock.json` stays consistent now, so we don't have things becoming out of date in the version that is getting installed without us realizing it.

Since Atom is now respecting `package-lock.json` this is an issue that we need to solve.

Note, this _should_ have been part of https://github.com/AtomLinter/linter-eslint/pull/1179, but it wasn't caught that that had only done the `devDependencies` when it was merged.