### PR TITLE
chore(readme): add info on linting other file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ installed
 for you. If you are using an alternative `linter-*` consumer feel free
 to disable the `linter` package.
 
-If you wish to lint files in JavaScript-derivative languages (like Typescript, Flow) with ESLint, you must add the scope name for that grammar to the `List of scopes to run ESLint on` option in `linter-eslint` Settings. For example, to lint TypeScript files, add `source.ts` to the list.
+If you wish to lint files in JavaScript-derivative languages (like Typescript,
+Flow) with ESLint, you must add the scope name for that grammar to the
+`List of scopes to run ESLint on` option in `linter-eslint` Settings. For
+example, to lint TypeScript files, add `source.ts` to the list.
 
 ## Use with plugins
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ installed
 for you. If you are using an alternative `linter-*` consumer feel free
 to disable the `linter` package.
 
-> **Important!** If you wish to lint other files besides JavaScript files (f.e. `.js`), you need to add them to `List of scopes to run ESLint on` option in linter-eslint settings. For example, to lint TypeScript files, you'll need to add `source.ts` to the list.
+If you wish to lint files in JavaScript-derivative languages (like Typescript, Flow) with ESLint, you must add the scope name for that grammar to the `List of scopes to run ESLint on` option in `linter-eslint` Settings. For example, to lint TypeScript files, add `source.ts` to the list.
 
 ## Use with plugins
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ installed
 for you. If you are using an alternative `linter-*` consumer feel free
 to disable the `linter` package.
 
+> **Important!** If you wish to lint other files besides JavaScript files (f.e. `.js`), you need to add them to `List of scopes to run ESLint on` option in linter-eslint settings. For example, to lint TypeScript files, you'll need to add `source.ts` to the list.
+
 ## Use with plugins
 
 You have two options:


### PR DESCRIPTION
I was scratching my head playing with `eslintrc` trying to figure why it wouldn't work, then I realized I had to add it to the scopes list when I stumbled on https://github.com/AtomLinter/linter-eslint/issues/1122 