### PR TITLE
Add source.flow to default scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "source.js",
         "source.jsx",
         "source.js.jsx",
+        "source.flow",
         "source.babel",
         "source.js-semantic"
       ],


### PR DESCRIPTION
Recent versions of atom do not add `source.js` in addition to `source.flow`,
treating flow as a completely different grammar from javascript, it seems.

This broke linting (along with other things) for flow users, unless
they added the flow source back to their config.  Instead, I think we should allow `linter-eslint` to "just work" for flow as well as regular javascript, which this
change will do.