### PR TITLE
chore: add ramda, fast-deep-equal, generic utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,9 @@
     "crypto-random-string": "3.3.1",
     "eslint": "4.19.1",
     "eslint-rule-documentation": "1.0.23",
+    "fast-deep-equal": "^2.0.1",
     "fs-plus": "3.1.1",
+    "ramda": "^0.26.0",
     "resolve-env": "1.0.0",
     "user-home": "2.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,9 @@ dependencies:
   crypto-random-string: 3.3.1
   eslint: 4.19.1
   eslint-rule-documentation: 1.0.23
+  fast-deep-equal: 2.0.1
   fs-plus: 3.1.1
+  ramda: 0.26.1
   resolve-env: 1.0.0
   user-home: 2.0.0
 devDependencies:
@@ -1051,6 +1053,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
+  /fast-deep-equal/2.0.1:
+    dev: false
+    resolution:
+      integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
   /fast-json-stable-stringify/2.1.0:
     dev: false
     resolution:
@@ -1671,6 +1677,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+  /ramda/0.26.1:
+    dev: false
+    resolution:
+      integrity: sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
   /read-pkg-up/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -2146,8 +2156,10 @@ specifiers:
   eslint-config-airbnb-base: 13.2.0
   eslint-plugin-import: 2.20.1
   eslint-rule-documentation: 1.0.23
+  fast-deep-equal: ^2.0.1
   fs-plus: 3.1.1
   jasmine-fix: 1.3.1
+  ramda: ^0.26.0
   resolve-env: 1.0.0
   rimraf: 3.0.2
   user-home: 2.0.0

--- a/spec/f-utils/deep-strict-diff-spec.js
+++ b/spec/f-utils/deep-strict-diff-spec.js
@@ -2,7 +2,7 @@
 
 import diff from '../../src/f-utils/deep-strict-diff'
 
-describe('deepDiff', () => {
+describe('deepStrictDiff', () => {
   it('finds added props', () => {
     const A = { prop1: { prop: 'value' } }
     const B = {

--- a/spec/f-utils/deep-strict-diff-spec.js
+++ b/spec/f-utils/deep-strict-diff-spec.js
@@ -1,0 +1,50 @@
+'use babel'
+
+import diff from '../../src/f-utils/deep-strict-diff'
+
+describe('deepDiff', () => {
+  it('finds added props', () => {
+    const A = { prop1: { prop: 'value' } }
+    const B = {
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' }
+    }
+
+    const { added } = diff(A, B)
+    expect(added).toEqual({ prop2: { prop: 'value' } })
+  })
+  it('finds removed props', () => {
+    const A = {
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' }
+    }
+    const B = { prop2: { prop: 'value' } }
+
+    const { removed } = diff(A, B)
+    expect(removed).toEqual({ prop1: { prop: 'value' } })
+  })
+  it('finds modified props', () => {
+    const A = {
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' },
+      prop3: { prop: 'value' }
+    }
+    const B = {
+      prop1: { differentProp: 'value' },
+      prop2: { prop: 'different value' }
+    }
+
+    const { added, removed } = diff(A, B)
+
+    expect(added).toEqual({
+      prop1: { differentProp: 'value' },
+      prop2: { prop: 'different value' }
+    })
+
+    expect(removed).toEqual({
+      prop1: { prop: 'value' },
+      prop2: { prop: 'value' },
+      prop3: { prop: 'value' }
+    })
+  })
+})

--- a/spec/f-utils/f-utils-spec.js
+++ b/spec/f-utils/f-utils-spec.js
@@ -1,0 +1,197 @@
+'use babel'
+
+import {
+  mapToObj,
+  objToMap,
+  notNil,
+  isUndef,
+  deepProp,
+  unique,
+  keyedFilter,
+  keyedMap
+} from '../../src/f-utils'
+
+describe('mapToObj', () => {
+  it('transforms a Map to an Object dictionary', () => {
+    const source = new Map([
+      ['a', 'some string'],
+      ['b', 10],
+      ['c', {}],
+      ['d', null],
+      ['e', undefined],
+      ['f', []]
+    ])
+
+    const expected = {
+      a: 'some string',
+      b: 10,
+      c: {},
+      d: null,
+      e: undefined,
+      f: []
+    }
+
+    expect(mapToObj(source)).toEqual(expected)
+  })
+})
+
+describe('objToMap', () => {
+  it('transforms an Object dictionary to a Map', () => {
+    const source = {
+      a: 'some string',
+      b: 25,
+      c: {},
+      d: null,
+      e: undefined,
+      f: []
+    }
+
+    const expected = new Map([
+      ['a', 'some string'],
+      ['b', 25],
+      ['c', {}],
+      ['d', null],
+      ['e', undefined],
+      ['f', []]
+    ])
+
+    expect(objToMap(source)).toEqual(expected)
+  })
+})
+
+describe('notNil', () => {
+  it('returns false for nil values', () => {
+    expect(notNil(undefined)).toBe(false)
+    expect(notNil(null)).toBe(false)
+  })
+
+  it('returns true for non-nil values', () => {
+    expect(notNil(true)).toBe(true)
+    expect(notNil(19)).toBe(true)
+    expect(notNil(0)).toBe(true)
+    expect(notNil({})).toBe(true)
+    expect(notNil(new Map())).toBe(true)
+    expect(notNil('')).toBe(true)
+  })
+})
+
+describe('isUndef', () => {
+  it('returns true for undefined values', () => {
+    const undef = undefined
+    expect(isUndef(undef)).toBe(true)
+    expect(isUndef()).toBe(true)
+  })
+
+  it('returns false for defined values', () => {
+    expect(isUndef(88)).toBe(false)
+    expect(isUndef(0)).toBe(false)
+    expect(isUndef('')).toBe(false)
+    expect(isUndef([])).toBe(false)
+    expect(isUndef({})).toBe(false)
+    expect(isUndef(null)).toBe(false)
+  })
+})
+
+describe('deepProp', () => {
+  it('finds a shallow prop', () => {
+    const obj = { a: '10' }
+    expect(deepProp('a', obj)).toBe('10')
+  })
+
+  it('finds a deep prop', () => {
+    const obj = { a: { b: { c: { d: { e: { g: 42 } } } } } }
+    expect(deepProp('a.b.c.d.e.g', obj)).toBe(42)
+  })
+
+  it('does not choke on falsy values', () => {
+    const obj = { a: { b: null } }
+    expect(deepProp('a.b', obj)).toBe(null)
+  })
+
+  it('does not choke on undefined trail', () => {
+    const obj = { a: { b: 'value' } }
+    expect(deepProp('some.unknown.prop.path', obj))
+      .toBe(undefined)
+  })
+})
+
+describe('unique', () => {
+  it('returns a new equivalent Array', () => {
+    const array = [1, 2, 3]
+    const uniqueArray = unique(array)
+
+    expect(uniqueArray).toEqual(array)
+    expect(uniqueArray).toNotBe(array)
+  })
+
+  it('removes duplicates', () => {
+    const array = [1, undefined, 2, 3, 3, 2, undefined]
+
+    const expected = [1, undefined, 2, 3]
+    expect(unique(array)).toEqual(expected)
+  })
+})
+
+describe('keyedFilter', () => {
+  it("adds index and original array to predicate's params", () => {
+    const array = [1, 2, 3]
+    let i = 0
+    const predicate = (value, index, arr) => {
+      expect(index).toBe(i)
+      expect(arr).toEqual(array)
+      i += 1
+      return value > 2
+    }
+    const expected = [3]
+
+    const result = keyedFilter(predicate, array)
+    expect(result).toEqual(expected)
+  })
+  it("adds key and original object to predicate's params", () => {
+    const keys = ['a', 'b', 'c']
+    const object = { a: 1, b: 2, c: 3 }
+    let i = 0
+    const predicate = (value, key, obj) => {
+      expect(keys.indexOf(key)).toBe(i)
+      expect(obj).toEqual(object)
+      i += 1
+      return key > 'b'
+    }
+    const expected = { c: 3 }
+
+    const result = keyedFilter(predicate, object)
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('keyedMap', () => {
+  it("adds index and original array to transformer's params", () => {
+    const array = [1, 2, 3]
+    let i = 0
+    const transformer = (value, index, arr) => {
+      expect(index).toBe(i)
+      expect(arr).toEqual(array)
+      i += 1
+      return value + 5
+    }
+    const expected = [6, 7, 8]
+
+    const result = keyedMap(transformer, array)
+    expect(result).toEqual(expected)
+  })
+  it("adds key and original object to transformer's params", () => {
+    const keys = ['a', 'b', 'c']
+    const object = { a: 1, b: 2, c: 3 }
+    let i = 0
+    const transformer = (value, key, obj) => {
+      expect(keys.indexOf(key)).toBe(i)
+      expect(obj).toEqual(object)
+      i += 1
+      return key
+    }
+    const expected = { a: 'a', b: 'b', c: 'c' }
+
+    const result = keyedMap(transformer, object)
+    expect(result).toEqual(expected)
+  })
+})

--- a/src/f-utils/deep-strict-diff.js
+++ b/src/f-utils/deep-strict-diff.js
@@ -1,0 +1,45 @@
+'use babel'
+
+import deepEq from 'fast-deep-equal'
+import { concat, compose as o } from './mini-ramda'
+import { unique } from '.'
+
+/** *****************************************
+ * deepStrictDiff                          *
+ *                                         *
+ * Strictly compare contents of 2 objects, *
+ * returning changes from a to b.          *
+ ****************************************** */
+
+// type Changes = { Object added, Object removed }
+// type Key = String
+
+// deepDiff :: a -> a -> Changes
+const deepStrictDiff = (a, b) => {
+  // uniqueKeys :: [Key]
+  const uniqueKeys = o(unique, concat)(
+    Object.keys(a),
+    Object.keys(b)
+  )
+
+  // diffReducer :: ((Changes, Key) -> Changes)
+  const diffReducer = ({ added, removed }, k) => {
+    /* eslint-disable no-param-reassign */
+    if (a[k] === undefined) {
+      added[k] = b[k]
+    } else if (b[k] === undefined) {
+      removed[k] = a[k]
+    } else if (deepEq(a[k], b[k]) === false) {
+      added[k] = b[k]
+      removed[k] = a[k]
+    }
+    return { added, removed }
+  }
+  /* eslint-enable */
+
+  return uniqueKeys.reduce(
+    diffReducer,
+    { added: {}, removed: {} }
+  )
+}
+export default deepStrictDiff

--- a/src/f-utils/index.js
+++ b/src/f-utils/index.js
@@ -1,0 +1,98 @@
+'use babel'
+
+import {
+  addIndex,
+  compose,
+  curry,
+  filter,
+  fromPairs,
+  isNil,
+  merge,
+  map,
+  not,
+  path as keysTrail,
+  reduce,
+  toPairs
+} from './mini-ramda'
+
+/** **************
+ * Typecasting *
+ ************** */
+
+// mapToObj :: Map -> Object
+export const mapToObj = m => fromPairs([...m])
+
+// objToMap :: Object -> Map
+export const objToMap = o => new Map(toPairs(o))
+
+
+/** ************
+ * Predicates *
+ ************* */
+
+// False on undefined or null, else true
+// isNotNil :: Any -> Boolean
+export const notNil = compose(not, isNil)
+
+// True on undefined, else false
+// isUndef :: Any -> Boolean
+export const isUndef = x => x === undefined
+
+
+/** *****************
+ * Extracting data *
+ ****************** */
+
+// Retreive value of nested property
+//  * deepProp('a.b.c.d', obj) --> obj.a.b.c.d *
+// deepProp :: String -> Object -> Any
+export const deepProp = curry(
+  (k, o) => keysTrail(k.split('.'), o)
+)
+
+
+/** *****************
+ * Transformations *
+ ****************** */
+
+// unique :: [a] -> [a]
+export const unique = xs => Array.from(new Set(xs))
+
+
+/** *******************************
+ * Modified callback signatures *
+ ******************************** */
+
+// Filter using additional key/index parameter
+// iFilter :: KeyedFilterable f
+//   => ((a, Int) -> Boolean) -> f a -> f a
+export const keyedFilter = curry(
+  (f, o) => (Array.isArray(o)
+    ? addIndex(filter)(f, o)
+    : reduce(
+      (filtered, k) => merge(
+        filtered,
+        f(o[k], k, o)
+          ? { [k]: o[k] }
+          : null
+      ),
+      {},
+      Object.keys(o)
+    ))
+)
+
+// Map using additional key/index parameter
+// iMap :: KeyedFunctor f
+//   => ((a, Int) -> b) -> f a -> f b
+export const keyedMap = curry(
+  (f, o) => (Array.isArray(o)
+    ? addIndex(map)(f, o)
+    : reduce(
+      (mapped, k) => merge(
+        mapped,
+        { [k]: f(o[k], k, o) }
+      ),
+      {},
+      Object.keys(o)
+    ))
+)

--- a/src/f-utils/mini-ramda.js
+++ b/src/f-utils/mini-ramda.js
@@ -1,0 +1,47 @@
+'use babel'
+
+// Curated list of Ramda functions
+//
+// Add to this list as needed.
+
+export { default as addIndex }
+  from 'ramda/src/addIndex'
+
+export { default as compose }
+  from 'ramda/src/compose'
+
+export { default as concat }
+  from 'ramda/src/concat'
+
+export { default as curry }
+  from 'ramda/src/curry'
+
+export { default as filter }
+  from 'ramda/src/filter'
+
+export { default as fromPairs }
+  from 'ramda/src/fromPairs'
+
+export { default as isNil }
+  from 'ramda/src/isNil'
+
+export { default as map }
+  from 'ramda/src/map'
+
+export { default as merge }
+  from 'ramda/src/merge'
+
+export { default as not }
+  from 'ramda/src/not'
+
+export { default as path }
+  from 'ramda/src/path'
+
+export { default as pipe }
+  from 'ramda/src/pipe'
+
+export { default as reduce }
+  from 'ramda/src/reduce'
+
+export { default as toPairs }
+  from 'ramda/src/toPairs'


### PR DESCRIPTION
* Add Ramda depenency and curated list to hide boilerplate of only importing
tools in use.
* Add fast-deep-equal dependency, for use on deepDiff utility.
* Add deepDiff utility.
* Add miscellaneous fp-oriented utilities:
    * mapToObj
    * objToMap
    * notNil
    * isUndef
    * deepProp
    * unique
    * keyedFilter
    * keyedMap

Signed-off-by: Sky Higgins <eveningsky@gmail.com>