### PR TITLE
Fix behavior when endColumn or endLine is null

### DIFF
--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -8,6 +8,8 @@ import rimraf from 'rimraf'
 import { beforeEach, it, fit } from 'jasmine-fix'
 import linterEslint from '../src/main'
 
+import { processESLintMessages } from '../src/helpers'
+
 const fixturesDir = path.join(__dirname, 'fixtures')
 
 const fixtures = {
@@ -704,5 +706,25 @@ describe('The eslint provider for Linter', () => {
         && typeof item.shouldDisplay === 'function'
       ))
     )))
+  })
+})
+
+describe('processESLintMessages', () => {
+  it('handles messages with null endColumn', async () => {
+    // Get a editor instance with at least a single line
+    const editor = await atom.workspace.open(paths.good)
+
+    const result = await processESLintMessages([{
+      column: null,
+      endColumn: null,
+      line: 1,
+      endLine: null,
+      message: 'Test Null endColumn',
+      nodeType: 'Block',
+      ruleId: 'test-null-endcolumn',
+      severity: 2,
+    }], editor, false)
+
+    expect(result[0].excerpt).toBe('Test Null endColumn')
   })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -274,7 +274,7 @@ export async function processESLintMessages(messages, textEditor, showRule) {
      keep doing so in later uses.
      */
     const msgLine = line - 1
-    if (typeof endColumn !== 'undefined' && typeof endLine !== 'undefined') {
+    if (typeof endColumn === 'number' && typeof endLine === 'number') {
       eslintFullRange = true
       // Here we always want the column to be a number
       msgCol = Math.max(0, column - 1)
@@ -283,7 +283,7 @@ export async function processESLintMessages(messages, textEditor, showRule) {
     } else {
       // We want msgCol to remain undefined if it was initially so
       // `generateRange` will give us a range over the entire line
-      msgCol = typeof column !== 'undefined' ? column - 1 : column
+      msgCol = typeof column === 'number' ? column - 1 : column
     }
 
     let ret = {


### PR DESCRIPTION
Fixes #1197, #1196, #1195, #1192 

The JSDoc plugin returns `null` when there isn't a end column. The ESLint API docs specifically say the type of `endColumn` and `endLine` are optional or must be a `number`, therefore it is probably more correct and safer to do that check instead of a undefined check: https://eslint.org/docs/developer-guide/working-with-plugins