### PR TITLE
add activation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,9 @@
       }
     }
   },
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "eslintConfig": {
     "rules": {
       "no-console": "off",

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -118,6 +118,10 @@ describe('The eslint provider for Linter', () => {
     atom.config.set('linter-eslint.advanced.disableFSCache', false)
     atom.config.set('linter-eslint.advanced.disableEslintIgnore', true)
 
+    // Activate activation hook
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
+
     // Activate the JavaScript language so Atom knows what the files are
     await atom.packages.activatePackage('language-javascript')
     // Activate the provider

--- a/spec/linter-eslint-spec.js
+++ b/spec/linter-eslint-spec.js
@@ -119,8 +119,8 @@ describe('The eslint provider for Linter', () => {
     atom.config.set('linter-eslint.advanced.disableEslintIgnore', true)
 
     // Activate activation hook
-    atom.packages.triggerDeferredActivationHooks();
-    atom.packages.triggerActivationHook('core:loaded-shell-environment');
+    atom.packages.triggerDeferredActivationHooks()
+    atom.packages.triggerActivationHook('core:loaded-shell-environment')
 
     // Activate the JavaScript language so Atom knows what the files are
     await atom.packages.activatePackage('language-javascript')


### PR DESCRIPTION
 This speeds up loading of Atom, by deferring the loading of linter-eslint until the core Atom shell is loaded. 