### PR TITLE
feat: add setting to select current working directory indicator file

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,13 @@
           "type": "string",
           "default": "",
           "order": 5
+        },
+        "cwdIndicatorFile": {
+          "title": "Current working directory indicator file",
+          "description": "Attempt to find this file and use it's location as eslint's current working directory (requires restart).",
+          "type": "string",
+          "default": "",
+          "order": 6
         }
       }
     }

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -139,6 +139,17 @@ export function getConfigPath(fileDir) {
 }
 
 export function getRelativePath(fileDir, filePath, config, projectPath) {
+  // If a current working directory indicator file is specified, try to find it to determine cwd
+  if (config.advanced.cwdIndicatorFile) {
+    const indicatorFile = findCached(fileDir, config.advanced.cwdIndicatorFile)
+
+    if (indicatorFile) {
+      const indicatorDir = Path.dirname(indicatorFile)
+      process.chdir(indicatorDir)
+      return Path.relative(indicatorDir, filePath)
+    }
+  }
+
   const ignoreFile = config.advanced.disableEslintIgnore ? null : findCached(fileDir, '.eslintignore')
 
   // If we can find an .eslintignore file, we can set cwd there


### PR DESCRIPTION
Currently the current working directory is determined by the location of .eslintignore by default.  I think rational behind this makes sense, but it would be a nice feature to have that configurable.  I currently do not use .eslintignore but have my project is in a sub folder.  This means linter-eslint selects the project root as the current working directory which breaks webpack import linting on my Vue.js projects.

After searching through a few of issues here, in vue cli, and other projects it looks like this is a fairly common point of confusion and use case.  Adding this setting would be a convenient feature and i think a lot of users when they discover the cwd is not what they expect might go searching in settings.  It would be nice to have something there to indicate how the cwd is selected.  

I added the setting to the uncommon section so it doesn't clutter more frequently used settings.  If unspecified (default) it should revert to the original behavior.  I thought it would be nice to make the default ".eslintignore" or something to indicate what it does currently, but there are a number of fall backs so I decided to keep it totally decoupled from the current behavior.