### PR TITLE
fix: fallback to other methods when global Eslint is not found

### DIFF
--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -47,10 +47,10 @@ function isDirectory(dirPath) {
   return isDir
 }
 
-export function findESLintDirectory(modulesDir, config, projectPath) {
+export function findESLintDirectory(modulesDir, config, projectPath, fallback = false) {
   let eslintDir = null
   let locationType = null
-  if (config.global.useGlobalEslint) {
+  if (config.global.useGlobalEslint && !fallback) {
     locationType = 'global'
     const configGlobal = cleanPath(config.global.globalNodePath)
     const prefixPath = configGlobal || getNodePrefixPath()
@@ -79,7 +79,8 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
   }
 
   if (config.global.useGlobalEslint) {
-    throw new Error('ESLint not found, please ensure the global Node path is set correctly.')
+    console.warn('ESLint not found, please ensure the global Node path is set correctly. \n Using other methods to find Eslint...')
+    findESLintDirectory(modulesDir, config, projectPath, true)
   }
 
   return {


### PR DESCRIPTION
This allows using Linter-Eslint even when the global Eslint is not found. Linting is better than no linting. 

Instead of `console.warn` we can use another method for informing the user.