### PR TITLE
Global Eslint improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,17 +71,16 @@ jobs:
           node-version: "12.x"
       - name: NPM install
         run: npm install
-      - name: Build and Commit
-        run: npm run build-commit
-      # NOTE: uncomment when ready
-      # - name: Release 🎉
-      #   uses: cycjimmy/semantic-release-action@v2
-      #   with:
-      #     extends: |
-      #       @semantic-release/apm-config
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     ATOM_ACCESS_TOKEN: ${{ secrets.ATOM_ACCESS_TOKEN  }}
+      # - name: Build and Commit
+      #   run: npm run build-commit
+      - name: Release 🎉
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          extends: |
+            @semantic-release/apm-config
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ATOM_ACCESS_TOKEN: ${{ secrets.ATOM_ACCESS_TOKEN  }}
 
   Skip:
     if: contains(github.event.head_commit.message, '[skip ci]')

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       "properties": {
         "useGlobalEslint": {
           "title": "Use global ESLint installation",
-          "description": "Make sure you have it in your $PATH",
+          "description": "Make sure you have it in your $PATH. ⚠️ Using the global ESLint install is heavily discouraged. If the installation is not found, linter-eslint will not work.",
           "type": "boolean",
           "default": false,
           "order": 1

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     },
     "global": {
       "type": "object",
+      "collapsed": true,
       "order": 4,
       "title": "Global ESLint",
       "properties": {

--- a/spec/worker-helpers-spec.js
+++ b/spec/worker-helpers-spec.js
@@ -120,12 +120,13 @@ describe('Worker Helpers', () => {
     })
 
     it('cries if global eslint is not found', () => {
-      expect(() => {
-        const config = createConfig({
-          global: { useGlobalEslint: true, globalNodePath: getFixturesPath('files') }
-        })
-        Helpers.getESLintInstance(getFixturesPath('local-eslint'), config)
-      }).toThrow()
+      const config = createConfig({
+        global: { useGlobalEslint: true, globalNodePath: getFixturesPath('files') }
+      })
+      spyOn(console, 'error')
+      Helpers.getESLintInstance(getFixturesPath('local-eslint'), config)
+      expect(console.error).toHaveBeenCalledWith(`Global ESLint is not found, please ensure the global Node path is set correctly.
+    If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.`)
     })
 
     it('tries to find a local eslint with nested node_modules', () => {

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -47,10 +47,10 @@ function isDirectory(dirPath) {
   return isDir
 }
 
-export function findESLintDirectory(modulesDir, config, projectPath) {
+export function findESLintDirectory(modulesDir, config, projectPath, fallback = false) {
   let eslintDir = null
   let locationType = null
-  if (config.global.useGlobalEslint) {
+  if (config.global.useGlobalEslint && !fallback) {
     locationType = 'global'
     const configGlobal = cleanPath(config.global.globalNodePath)
     const prefixPath = configGlobal || getNodePrefixPath()
@@ -79,7 +79,8 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
   }
 
   if (config.global.useGlobalEslint) {
-    throw new Error('ESLint not found, please ensure the global Node path is set correctly.')
+    console.warn('ESLint not found, please ensure the global Node path is set correctly. \n Using other methods to find Eslint...')
+    findESLintDirectory(modulesDir, config, projectPath, true)
   }
 
   return {

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -79,7 +79,7 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
   }
 
   if (config.global.useGlobalEslint) {
-    throw new Error('ESLint not found, please ensure the global Node path is set correctly.')
+    throw new Error('Global ESLint is not found, please ensure the global Node path is set correctly. If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.')
   }
 
   return {

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -47,10 +47,10 @@ function isDirectory(dirPath) {
   return isDir
 }
 
-export function findESLintDirectory(modulesDir, config, projectPath) {
+export function findESLintDirectory(modulesDir, config, projectPath, fallback = false) {
   let eslintDir = null
   let locationType = null
-  if (config.global.useGlobalEslint) {
+  if (config.global.useGlobalEslint && !fallback) {
     locationType = 'global'
     const configGlobal = cleanPath(config.global.globalNodePath)
     const prefixPath = configGlobal || getNodePrefixPath()
@@ -79,7 +79,10 @@ export function findESLintDirectory(modulesDir, config, projectPath) {
   }
 
   if (config.global.useGlobalEslint) {
-    throw new Error('Global ESLint is not found, please ensure the global Node path is set correctly. If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.')
+    // TODO push the error to the user
+    console.error(`Global ESLint is not found, please ensure the global Node path is set correctly.
+    If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.`)
+    findESLintDirectory(modulesDir, config, projectPath, true)
   }
 
   return {

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -47,10 +47,10 @@ function isDirectory(dirPath) {
   return isDir
 }
 
-export function findESLintDirectory(modulesDir, config, projectPath, fallback = false) {
+export function findESLintDirectory(modulesDir, config, projectPath) {
   let eslintDir = null
   let locationType = null
-  if (config.global.useGlobalEslint && !fallback) {
+  if (config.global.useGlobalEslint) {
     locationType = 'global'
     const configGlobal = cleanPath(config.global.globalNodePath)
     const prefixPath = configGlobal || getNodePrefixPath()
@@ -79,8 +79,7 @@ export function findESLintDirectory(modulesDir, config, projectPath, fallback = 
   }
 
   if (config.global.useGlobalEslint) {
-    console.warn('ESLint not found, please ensure the global Node path is set correctly. \n Using other methods to find Eslint...')
-    findESLintDirectory(modulesDir, config, projectPath, true)
+    throw new Error('ESLint not found, please ensure the global Node path is set correctly.')
   }
 
   return {


### PR DESCRIPTION
- This improves the message of error for missing Global Eslint. 
- Adds a warning in the config for using this option.
- Makes the option collapsed in the settings view.

Take 2 of #1370. @Arcanemagus I edited the PR based on [your feedback](https://github.com/AtomLinter/linter-eslint/pull/1370#issuecomment-717557496).