### PR TITLE
fix: require an up to date Linter package

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
   "package-deps": [
     {
       "name": "linter",
-      "minimumVersion": "2.0.0"
+      "minimumVersion": "3.3.0"
     }
   ],
   "providedServices": {


### PR DESCRIPTION
We always test on the latest version, so we can't guarantee that the latest version of linter-eslint works on the older versions.
If someone insists on using an outdated version of the Linter package, they need to downgrade linter-eslint