### PR TITLE
fix: fix stackoverflow for fallbackForGlobal error

### DIFF
--- a/spec/worker-helpers-spec.js
+++ b/spec/worker-helpers-spec.js
@@ -127,8 +127,9 @@ describe('Worker Helpers', () => {
       })
       spyOn(console, 'error')
       Helpers.getESLintInstance(getFixturesPath('local-eslint'), config)
-      expect(console.error).toHaveBeenCalledWith(`Global ESLint is not found, please ensure the global Node path is set correctly.
-    If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.`)
+      expect(console.error).toHaveBeenCalledWith(`Global ESLint is not found, falling back to other Eslint installations...
+        Please ensure the global Node path is set correctly.
+        If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.`)
     })
 
     it('tries to find a local eslint with nested node_modules', () => {

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -47,10 +47,12 @@ function isDirectory(dirPath) {
   return isDir
 }
 
-export function findESLintDirectory(modulesDir, config, projectPath, fallback = false) {
+let fallbackForGlobalErrorThrown = false
+
+export function findESLintDirectory(modulesDir, config, projectPath, fallbackForGlobal = false) {
   let eslintDir = null
   let locationType = null
-  if (config.global.useGlobalEslint && !fallback) {
+  if (config.global.useGlobalEslint && !fallbackForGlobal) {
     locationType = 'global'
     const configGlobal = cleanPath(config.global.globalNodePath)
     const prefixPath = configGlobal || getNodePrefixPath()
@@ -78,11 +80,15 @@ export function findESLintDirectory(modulesDir, config, projectPath, fallback = 
     }
   }
 
-  if (config.global.useGlobalEslint) {
-    // TODO push the error to the user
-    console.error(`Global ESLint is not found, please ensure the global Node path is set correctly.
-    If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.`)
-    findESLintDirectory(modulesDir, config, projectPath, true)
+  if (config.global.useGlobalEslint && !fallbackForGlobal) {
+    if (!fallbackForGlobalErrorThrown) {
+      // Throw the error only once to prevent performance issues
+      fallbackForGlobalErrorThrown = true
+      console.error(`Global ESLint is not found, falling back to other Eslint installations...
+        Please ensure the global Node path is set correctly.
+        If you wanted to use a local installation of Eslint, disable Global Eslint option in the linter-eslint config.`)
+    }
+    return findESLintDirectory(modulesDir, config, projectPath, true)
   }
 
   return {


### PR DESCRIPTION
This fixes a StackOverflow that happened because of missing `return`. Also, now the errors are pushed to the user.

### Test verification

Open a .js + .eslintrc.json file in an empty folder, and enable globalEslint config (assuming you don't have eslint installed globally)