### PR TITLE
Cherry-pick version agnostic changes from #1360

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "root": true,
     "rules": {
       "no-console": "off",
+      "max-len": [1, { "code": 130 }],
       "semi": [
         "error",
         "never"

--- a/package.json
+++ b/package.json
@@ -184,11 +184,13 @@
     "resolve-env": "1.0.0"
   },
   "devDependencies": {
-    "@types/atom": "^1.40.10",
-    "@types/jasmine": "^3.7.7",
-    "@types/rimraf": "^3.0.0",
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.14.6",
+    "@types/atom": "^1.40.10",
+    "@types/eslint": "4",
+    "@types/jasmine": "^3.7.7",
+    "@types/node": "^14.14.35",
+    "@types/rimraf": "^3.0.0",
     "atom-jasmine3-test-runner": "^5.2.6",
     "babel-preset-atomic": "^3.2.1",
     "build-commit": "^0.1.4",
@@ -218,7 +220,12 @@
     "root": true,
     "rules": {
       "no-console": "off",
-      "max-len": [1, { "code": 130 }],
+      "max-len": [
+        1,
+        {
+          "code": 130
+        }
+      ],
       "semi": [
         "error",
         "never"

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
     "core:loaded-shell-environment"
   ],
   "eslintConfig": {
+    "root": true,
     "rules": {
       "no-console": "off",
       "semi": [
@@ -249,7 +250,7 @@
     },
     "extends": "airbnb-base",
     "globals": {
-      "atom": "true"
+      "atom": "readonly"
     },
     "env": {
       "node": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,9 @@ specifiers:
   '@babel/cli': ^7.14.5
   '@babel/core': ^7.14.6
   '@types/atom': ^1.40.10
+  '@types/eslint': '4'
   '@types/jasmine': ^3.7.7
+  '@types/node': ^14.14.35
   '@types/rimraf': ^3.0.0
   atom-jasmine3-test-runner: ^5.2.6
   atom-linter: 10.0.0
@@ -39,7 +41,9 @@ devDependencies:
   '@babel/cli': 7.14.5_@babel+core@7.14.6
   '@babel/core': 7.14.6
   '@types/atom': 1.40.10
+  '@types/eslint': 4.16.8
   '@types/jasmine': 3.7.7
+  '@types/node': 14.17.3
   '@types/rimraf': 3.0.0
   atom-jasmine3-test-runner: 5.2.6
   babel-preset-atomic: 3.2.1_ca51ed81783c07d12d613b7bff6a502d
@@ -1427,6 +1431,17 @@ packages:
       '@types/node': 14.14.35
     dev: true
 
+  /@types/eslint/4.16.8:
+    resolution: {integrity: sha512-n0ZvaIpPeBxproRvV+tZoCHRxIoNAk+k+XMvQefKgx3qM3IundoogQBAwiNEnqW0GDP1j1ATe5lFy9xxutFAHg==}
+    dependencies:
+      '@types/estree': 0.0.48
+      '@types/json-schema': 7.0.7
+    dev: true
+
+  /@types/estree/0.0.48:
+    resolution: {integrity: sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==}
+    dev: true
+
   /@types/glob/7.1.3:
     resolution: {integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==}
     dependencies:
@@ -1436,6 +1451,10 @@ packages:
 
   /@types/jasmine/3.7.7:
     resolution: {integrity: sha512-yZzGe1d1T0y+imXDZ79F030nn8qbmiwpWKCZKvKN0KbTzwXAVYShUxkIxu1ba+vhIdabTGVGCfbtZC0oOam8TQ==}
+    dev: true
+
+  /@types/json-schema/7.0.7:
+    resolution: {integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==}
     dev: true
 
   /@types/json5/0.0.29:
@@ -1448,6 +1467,10 @@ packages:
 
   /@types/node/14.14.35:
     resolution: {integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==}
+    dev: true
+
+  /@types/node/14.17.3:
+    resolution: {integrity: sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==}
     dev: true
 
   /@types/parse-json/4.0.0:

--- a/spec/fixtures/import-resolution/.eslintrc.yaml
+++ b/spec/fixtures/import-resolution/.eslintrc.yaml
@@ -10,3 +10,4 @@
 
   parserOptions:
     sourceType: "module"
+    ecmaVersion: 2015

--- a/src/rules.js
+++ b/src/rules.js
@@ -6,22 +6,23 @@ import ruleURI from 'eslint-rule-documentation'
 export default class Rules {
   /**
    * Instantiates a Rules object, optionally with an existing list of rules
-   * @param {Array<Array<string, any>} newRules Array of Arrays of the rule and properties
+   * @param {Array<Array<string, any> | undefined} newRules Array of Arrays of the rule and properties
    */
   constructor(newRules) {
+    // TODO we should not accept undefined newRules.
     this.replaceRules(newRules)
   }
 
   /**
    * Process the updated rules into the local Map and call further update functions
-   * @param  {Array<Array<string, any>} newRules Array of Arrays of the rule and properties
+   * @param  {Array<Array<string, any> | undefined} newRules Array of Arrays of the rule and properties
    */
   replaceRules(newRules) {
     if (this.rules !== undefined) {
       this.rules.clear()
     }
 
-    /** @type {Map<string, any>} */
+    /** @type {Map<string, any>} if newRules is {undefined} an empty Map is created */
     this.rules = new Map(newRules)
   }
 

--- a/src/worker-helpers.js
+++ b/src/worker-helpers.js
@@ -19,6 +19,9 @@ const Cache = {
  */
 const cleanPath = path => (path ? resolveEnv(fs.normalize(path)) : '')
 
+/**
+ * @returns {string}
+ */
 export function getNodePrefixPath() {
   if (Cache.NODE_PREFIX_PATH === null) {
     const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
@@ -35,6 +38,10 @@ export function getNodePrefixPath() {
   return Cache.NODE_PREFIX_PATH
 }
 
+/**
+ * @param {string} dirPath
+ * @returns {boolean}
+ */
 function isDirectory(dirPath) {
   let isDir
   try {
@@ -47,6 +54,13 @@ function isDirectory(dirPath) {
 
 let fallbackForGlobalErrorThrown = false
 
+/**
+ * @param {string} modulesDir
+ * @param {object} config
+ * @param {string} projectPath
+ * @param {boolean} fallbackForGlobal
+ * @returns {{ path: string, type: 'local project' | 'global' | 'advanced specified' | 'bundled fallback' }}
+ */
 export function findESLintDirectory(modulesDir, config, projectPath, fallbackForGlobal = false) {
   let eslintDir = null
   let locationType = null
@@ -95,6 +109,12 @@ export function findESLintDirectory(modulesDir, config, projectPath, fallbackFor
   }
 }
 
+/**
+ * @param {string} modulesDir
+ * @param {object} config
+ * @param {string} projectPath
+ * @returns {import("eslint")}
+ */
 export function getESLintFromDirectory(modulesDir, config, projectPath) {
   const { path: ESLintDirectory } = findESLintDirectory(modulesDir, config, projectPath)
   try {
@@ -109,6 +129,9 @@ export function getESLintFromDirectory(modulesDir, config, projectPath) {
   }
 }
 
+/**
+ * @param {string} modulesDir
+ */
 export function refreshModulesPath(modulesDir) {
   if (Cache.LAST_MODULES_PATH !== modulesDir) {
     Cache.LAST_MODULES_PATH = modulesDir
@@ -118,12 +141,22 @@ export function refreshModulesPath(modulesDir) {
   }
 }
 
+/**
+ * @param {string} fileDir
+ * @param {object} config
+ * @param {string} projectPath
+ * @returns {import("eslint")}
+ */
 export function getESLintInstance(fileDir, config, projectPath) {
   const modulesDir = Path.dirname(findCached(fileDir, 'node_modules/eslint') || '')
   refreshModulesPath(modulesDir)
   return getESLintFromDirectory(modulesDir, config, projectPath)
 }
 
+/**
+ * @param {import("eslint")} eslint
+ * @param {string} filePath
+ */
 export function getConfigForFile(eslint, filePath) {
   const cli = new eslint.CLIEngine()
   try {
@@ -134,6 +167,13 @@ export function getConfigForFile(eslint, filePath) {
   }
 }
 
+/**
+ * @param {string} fileDir
+ * @param {string} filePath
+ * @param {object} config
+ * @param {string} projectPath
+ * @returns {string}
+ */
 export function getRelativePath(fileDir, filePath, config, projectPath) {
   const ignoreFile = config.advanced.disableEslintIgnore ? null : findCached(fileDir, '.eslintignore')
 
@@ -154,6 +194,13 @@ export function getRelativePath(fileDir, filePath, config, projectPath) {
   return Path.basename(filePath)
 }
 
+/**
+ * @param {string} type
+ * @param {string[]} rules
+ * @param {object} config
+ * @param {string} filePath
+ * @param {object} fileConfig
+ */
 export function getCLIEngineOptions(type, config, rules, filePath, fileConfig) {
   const cliEngineConfig = {
     rules,
@@ -179,7 +226,7 @@ export function getCLIEngineOptions(type, config, rules, filePath, fileConfig) {
 
 /**
  * Gets the list of rules used for a lint job
- * @param  {Object} cliEngine The CLIEngine instance used for the lint job
+ * @param  {import("eslint").CLIEngine} cliEngine The CLIEngine instance used for the lint job
  * @return {Map}              A Map of the rules used, rule names as keys, rule
  *                            properties as the contents.
  */


### PR DESCRIPTION
This cherry-picks the changes from #1360 that do not depend on the version of Eslint. This makes it easier to fix the failing tests in #1360